### PR TITLE
Enclave Wrangler: Dataset upload & Moffit transform

### DIFF
--- a/.run/enclave_wrangler-for-moffit.run.xml
+++ b/.run/enclave_wrangler-for-moffit.run.xml
@@ -1,0 +1,34 @@
+<component name="ProjectRunConfigurationManager">
+  <configuration default="false" name="enclave_wrangler-for-moffit" type="PythonConfigurationType" factoryName="Python" folderName="enclave_wrangler">
+    <module name="TermHub" />
+    <option name="INTERPRETER_OPTIONS" value="" />
+    <option name="PARENT_ENVS" value="true" />
+    <envs>
+      <env name="PYTHONUNBUFFERED" value="1" />
+    </envs>
+    <option name="SDK_HOME" value="" />
+    <option name="WORKING_DIRECTORY" value="$PROJECT_DIR$" />
+    <option name="IS_MODULE_SDK" value="true" />
+    <option name="ADD_CONTENT_ROOTS" value="true" />
+    <option name="ADD_SOURCE_ROOTS" value="true" />
+    <EXTENSION ID="PythonCoverageRunConfigurationExtension" runner="coverage.py" />
+    <EXTENSION ID="net.ashald.envfile">
+      <option name="IS_ENABLED" value="false" />
+      <option name="IS_SUBST" value="false" />
+      <option name="IS_PATH_MACRO_SUPPORTED" value="false" />
+      <option name="IS_IGNORE_MISSING_FILES" value="false" />
+      <option name="IS_ENABLE_EXPERIMENTAL_INTEGRATIONS" value="false" />
+      <ENTRIES>
+        <ENTRY IS_ENABLED="true" PARSER="runconfig" />
+      </ENTRIES>
+    </EXTENSION>
+    <option name="SCRIPT_NAME" value="$PROJECT_DIR$/enclave_wrangler/dataset_upload.py" />
+    <option name="PARAMETERS" value="-p termhub-csets/datasets/uploads/moffit/2022-10-05/2022-10-05.csv -f moffit" />
+    <option name="SHOW_COMMAND_LINE" value="false" />
+    <option name="EMULATE_TERMINAL" value="false" />
+    <option name="MODULE_MODE" value="false" />
+    <option name="REDIRECT_INPUT" value="false" />
+    <option name="INPUT_FILE" value="" />
+    <method v="2" />
+  </configuration>
+</component>

--- a/enclave_wrangler/dataset_upload.py
+++ b/enclave_wrangler/dataset_upload.py
@@ -1,0 +1,615 @@
+"""Upload datasets to Foundry"""
+import json
+import os
+from argparse import ArgumentParser
+from typing import Dict, List, Set, Union
+from uuid import uuid4
+
+import pandas as pd
+
+
+try:
+    from enclave_wrangler.config import config, PROJECT_ROOT, TERMHUB_CSETS_DIR
+    from enclave_wrangler.enclave_api import get_cs_container_data, get_cs_version_data, get_cs_version_expression_data, \
+    post_request_enclave_api_addExpressionItems, post_request_enclave_api_create_container, \
+    post_request_enclave_api_create_version, \
+    update_cs_version_expression_data_with_codesetid
+    from enclave_wrangler.utils import _datetime_palantir_format, log_debug_info
+except ModuleNotFoundError:
+    from config import config, PROJECT_ROOT, TERMHUB_CSETS_DIR
+    from enclave_api import get_cs_container_data, get_cs_version_data, get_cs_version_expression_data, \
+        post_request_enclave_api_addExpressionItems, post_request_enclave_api_create_container, \
+        post_request_enclave_api_create_version, \
+        update_cs_version_expression_data_with_codesetid
+    from utils import _datetime_palantir_format, log_debug_info
+
+
+DEBUG = False
+PALANTIR_ENCLAVE_USER_ID_1 = 'a39723f3-dc9c-48ce-90ff-06891c29114f'
+MOFFIT_PREFIX = 'Simplified autoimmune disease'
+MOFFIT_SOURCE_URL = 'https://docs.google.com/spreadsheets/d/1tHHHeMtzX0SA85gbH8Mvw2E0cxH-x1ii/edit#gid=1762989244'
+MOFFIT_SOURCE_ID_TYPE = 'moffit'
+ENCLAVE_PROJECT_NAME = 'RP-4A9E27'
+UPLOADS_DIR = os.path.join(TERMHUB_CSETS_DIR, 'datasets', 'uploads')
+CSET_UPLOAD_REGISTRY_PATH = os.path.join(UPLOADS_DIR, 'cset_upload_registry.csv')
+
+
+def post_to_enclave_and_update_code_sets_csv(input_csv_folder_path) -> pd.DataFrame:
+    """Uploads data to enclave and updates the following column in the input's code_sets.csv:
+    - enclave_codeset_id
+    - enclave_codeset_id_updated_at
+    - concept_set_name"""
+    if DEBUG:
+        log_debug_info()
+
+    # Read data
+    code_sets_df = _load_standardized_input_df(os.path.join(input_csv_folder_path, 'code_sets.csv')) #.fillna('')
+
+    # 0.1 Create mappings between
+    # - concept_set_container_edited.csv[concept_set_name], and...
+    # - code_sets.csv[codeset_id]
+    # use the concept_set_name as key to store the pre-made codeset_ids,
+    # store the codeset_ids in the premade_codeset_ids
+    cs_name_id_mappings = {}
+    for index, row in code_sets_df.iterrows():
+        cs_id = row['codeset_id']
+        cs_name = row['concept_set_name']
+        cs_name_id_mappings[cs_name] = cs_id
+    # 0.2 create a list of premade coedeset ids
+    premade_codeset_ids = []
+    for index, row in code_sets_df.iterrows():
+        premade_codeset_ids.append(row['codeset_id'])
+
+    # I. Create structures
+    # I.0. concept_set_version_item_dict; key=codeset_id
+    concept_set_version_item_dict = {}
+    concept_set_version_item_rv_edited_df = pd.read_csv(
+        os.path.join(input_csv_folder_path, 'concept_set_version_item_rv_edited.csv')).fillna('')
+    for index, row in concept_set_version_item_rv_edited_df.iterrows():
+        key = row['codeset_id']
+        if key not in concept_set_version_item_dict:
+            concept_set_version_item_dict[key] = []
+        concept_set_version_item_dict[key].append(row)
+    # cs_result = pd.merge(code_sets_df, concept_set_version_item_rv_edited_df, on=['codeset_id'])
+
+    # I.1. build the list of container json data; key=codeset_id
+    # I.1.ii. Get the actual container data
+    concept_set_container_edited_json_all_rows = {}
+    concept_set_container_edited_df = pd.read_csv(
+        os.path.join(input_csv_folder_path, 'concept_set_container_edited.csv')).fillna('')
+    for index, row in concept_set_container_edited_df.iterrows():
+        cs_name = row['concept_set_name'].strip()
+        single_row = get_cs_container_data(cs_name)
+        cs_id = cs_name_id_mappings[cs_name]
+        concept_set_container_edited_json_all_rows[cs_id] = single_row
+
+    # I.2. build the list of cs version json data; key=codeset_id
+    code_set_version_json_all_rows = {}
+    # code_sets_df = pd.read_csv(os.path.join(input_csv_folder_path, 'code_sets.csv')).fillna('')
+    for index, row in code_sets_df.iterrows():
+        cs_id = row['codeset_id']
+        cs_name = row['concept_set_name'].strip()
+        cs_intention = row['intention'].strip()
+        cs_limitations = row['limitations'].strip()
+        cs_update_msg = row['update_message'].strip()
+        cs_authority = row.get('authority', '').strip()
+        ##cs_authority = "Mathematica"  ## TODO: shong, 4/26/22, code_sets.csv need to build the authority value, uncomment when available
+        cs_provenance = row['provenance'].strip()
+        single_row = get_cs_version_data(cs_name, cs_id, cs_intention, cs_limitations, cs_update_msg, cs_provenance, cs_authority)
+        # cs_name, cs_id, intention, limitation, update_msg, status, provenance
+        code_set_version_json_all_rows[cs_id] = single_row
+        # code_set_version_json_all_rows_dict[codeset_id] = single_row
+
+    # I.3. Build all of the Expression items to add to a CS version; key=codeset_id,
+    # codeset_id = pre-made codeset_id to iterate through the codesets
+    code_set_expression_items_json_all_rows = {}
+    for index, row in code_sets_df.iterrows():
+        current_code_set_id = row['codeset_id']
+        # build the code and codeSystem list for the current codeSet
+        # reset the code list
+        code_list = []
+        cs_name = row['concept_set_name'].strip()
+        # code and code system list
+        concept_set_version_item_rows = concept_set_version_item_dict[current_code_set_id]
+        # always use the same entry from the first set as currently
+        # we do not have a support to save these flags per expressionItems
+        concept_set_version_item_row1 = concept_set_version_item_rows[0]
+        exclude = concept_set_version_item_row1['isExcluded']
+        descendents = concept_set_version_item_row1['includeDescendants']
+        mapped = concept_set_version_item_row1['includeMapped']
+        annotation = concept_set_version_item_row1['annotation'].strip()
+
+        for concept_set_version_item_row in concept_set_version_item_rows:
+            code_codesystem_pair = concept_set_version_item_row['codeSystem'] + ":" + str(concept_set_version_item_row['code'])
+            code_list.append(code_codesystem_pair)
+            # to-do(future): Right now, the API doesn't expect variation between the following 4 values among
+            # ...concept set items, so right now we can just take any of the rows and use its values. But, in
+            # ...the future, when there is variation, we may need to do some update here. - Joe 2022/02/04
+            # this is same limitation OMOP concept expression works, so for now it is sufficient
+            # we can explorer more granular control later if necessary -Stephanie 02/05/2022
+
+            # now that we have the code list, generate the json for the versionExpression data
+            single_row = get_cs_version_expression_data(current_code_set_id, cs_name, code_list, exclude, descendents, mapped, annotation)
+            code_set_expression_items_json_all_rows[current_code_set_id] = single_row
+            # code_set_expression_items_json_all_rows_dict[codeset_id] = single_row
+
+            # now that we have the code list, generate the json for the versionExpression data
+            single_row = get_cs_version_expression_data(
+                current_code_set_id, cs_name, code_list, exclude, descendents, mapped, annotation)
+            code_set_expression_items_json_all_rows[current_code_set_id] = single_row
+            # code_set_expression_items_json_all_rows_dict[codeset_id] = single_row
+
+    # --- Steph: check the failed cases 2/15/22-----------------------------
+    # @Steph: Can we remove this block yet? I don't mind keeping for a while for convenienice, but I like the practice
+    # ...of keeping code like this inside a copy of the file in a git ignored folder. - Joe 2022/03/15
+    # begin test code
+    # for premade_codeset_id in premade_codeset_ids:
+    #    # we have problem with very large code list - 16(3623) and 39(5104) 58(1820) 73(6791) 74(1501)
+    #    upd_cs_ver_expression_items_dict1 = code_set_expression_items_json_all_rows[premade_codeset_id]
+    #    codeStringList1 = upd_cs_ver_expression_items_dict1['parameters'][
+    #        'ri.actions.main.parameter.c9a1b531-86ef-4f80-80a5-cc774d2e4c33']['stringList']['strings']
+    #    print( str(premade_codeset_id) + "codelistLength: " + str(len(codeStringList1)))
+    #    print('------')
+    # end test code ------------------------------- #
+
+    # II. call the REST APIs to create them on the Enclave
+    # ...now that we have all the data from concept set are created
+    # temp_testing_cset_id = 1000000326  # Stephanie said this was a draft or archived set - Joe 2022/03/15
+    for premade_codeset_id in premade_codeset_ids:
+        # TODO: temporary debug code to look for missing concept container not showing in the UI
+        # TODO: debug code for adding expressionItems to missing container from UI, l162,l163
+
+        #    if premade_codeset_id != temp_testing_cset_id:
+        #        continue
+
+        # Do a test first using 'validate'
+        header = {
+                "authorization": f"Bearer {config['PALANTIR_ENCLAVE_AUTHENTICATION_BEARER_TOKEN']}",
+                'content-type': 'application/json'
+        }
+
+        container_data_dict = concept_set_container_edited_json_all_rows[premade_codeset_id]
+        # noinspection PyUnusedLocal
+        # response_json = post_request_enclave_api(api_url, header, test_data_dict)
+        # create concept set containe:
+        #  ----- container_data_dict['parameters']['ri.actions.main.parameter.1b5cd6e9-b220-4551-b97d-245b9fa86807']
+        # 'ri.actions.main.parameter.1b5cd6e9-b220-4551-b97d-245b9fa86807': {
+        #   'type': 'string', 'string': '[VSAC] Eclampsia'},
+        # if DEBUG:
+        #     csContainerName = container_data_dict[
+        #         'parameters']['ri.actions.main.parameter.1b5cd6e9-b220-4551-b97d-245b9fa86807']['string']
+        #     print(csContainerName)
+        #     print('------------------------------')
+        response_json = post_request_enclave_api_create_container(header, container_data_dict)
+        # i.e container object may already exist but we can create another version within a container:
+        # {'errorCode': 'INVALID_ARGUMENT', 'errorName': 'Actions:ObjectsAlreadyExist',
+        # 'errorInstanceId': '96fb2188-1947-4004-a7b3-d0572a5a0008', 'parameters': {'objectLocators':
+        # '[ObjectLocator{objectTypeId: omop-concept-set-container, primaryKey: {concept_set_id=PrimaryKeyValue{
+        #   value: StringWrapper{value: [VSAC] Mental Behavioral and Neurodevelopmental Disorders}}}}]'}}
+        # Validate 2: Concept set version item
+        # noinspection PyUnusedLocal
+        # DEBUG:urllib3.connectionpool:https://unite.nih.gov:443 "POST /actions/api/actions HTTP/1.1" 200 107
+        # {'actionRid': 'ri.actions.main.action.9dea4a02-fb9c-4009-b623-b91ad6a0192b', 'synchronouslyPropagated': False}
+        # Actually create a version so that we can test the api to add the expression items
+
+        # cs_version_data_dict = code_set_version_json_all_rows[0]
+        cs_version_data_dict = code_set_version_json_all_rows[premade_codeset_id]
+        # noinspection PyUnusedLocal
+        # create the version and ask Enclave for the codeset_id that can be used to addCodeExpressionItems
+        # create version -----
+        codeset_id = post_request_enclave_api_create_version(header, cs_version_data_dict)
+        # TODO begin ------------------------------------------------------------
+        # 3/14/22, stephanie, save the codeset_id with container name in csContainerName
+        # save codeset_id of a draft version with the container name saved in container_name= container_data_dict[
+        #   'parameters']['ri.actions.main.parameter.1b5cd6e9-b220-4551-b97d-245b9fa86807']['string']
+        # premade_codeset_id = dih internal id
+        # csContainerName = container name
+        # codeset_id = version id
+        # --persist the data in the output folder = input_csv_folder_path
+        # end TODO---------------------------------------------------------------
+        # upd_cs_ver_expression_items_dict = code_set_expression_items_json_all_rows[item]
+        upd_cs_ver_expression_items_dict: Dict = code_set_expression_items_json_all_rows[premade_codeset_id]
+        # update the payload with the codeset_id returned from the
+
+        # DEBUG: Can use this to check to make sure code list is OK:
+        # if DEBUG: # updated json data is saved in upd_cs_ver_expression_items_dict
+        cs_container_name = container_data_dict[
+            'parameters']['ri.actions.main.parameter.1b5cd6e9-b220-4551-b97d-245b9fa86807']['string']
+        print('csContainerName: ' + str(cs_container_name))
+        string_list = upd_cs_ver_expression_items_dict[
+            'parameters']['ri.actions.main.parameter.c9a1b531-86ef-4f80-80a5-cc774d2e4c33']['stringList']['strings']
+        print('premade_codeset_id: ' + str(premade_codeset_id))
+        print('len(stringList): ' + str(len(string_list)))
+        print('codeset_id: ' + str(codeset_id))
+        print('------------------------------')
+
+        # update the json data with the correct codeset_id -----
+        upd_cs_ver_expression_items_dict = \
+            update_cs_version_expression_data_with_codesetid(codeset_id, upd_cs_ver_expression_items_dict)
+        # Validate 3: add the concept set expressions to draft version by passing as code and code system
+        # third api
+        # https://unite.nih.gov/workspace/ontology/action-type/add-code-system-codes-as-omop-version-expressions/overview
+        # action type rid: ri.actions.main.action-type.e07f2503-c7c9-47b9-9418-225544b56b71
+        # noinspection PyUnusedLocal
+        # add expressionItems to version -----
+        response_json = post_request_enclave_api_addExpressionItems(header, upd_cs_ver_expression_items_dict)
+        print('post request to add expressionItems returned: ----------' + json.dumps(response_json))
+        # Once the expression items has been added save the enclave concept_id so that we can update the code_sets.csv
+        # file update code_sets_df with the enclave_codeset_id column of the  value in the codeset_id retured from the
+        # enclave and if needed we can also save the json data in upd_cs_ver_expression_items_dict premade_codeset_id is
+        # stored in the codeset_id column in the csv files, save the id in the enclave_codeset_id column update when it
+        # was uploaded as well, Stephane 3/15/22
+        try:
+            code_sets_df.set_index('codeset_id', inplace=True)
+        except Exception as e:
+            print(e)
+
+        code_sets_df.at[premade_codeset_id, 'enclave_codeset_id'] = codeset_id
+        code_sets_df.at[premade_codeset_id, 'enclave_codeset_id_updated_at'] = _datetime_palantir_format()
+        code_sets_df = code_sets_df.reset_index()
+        # return response_json
+
+    # write out the update csv file with the enclave_codeset_id
+    # print('before terminating write out the updated code_sets.csv file here')
+    # date_str = datetime.now().strftime('%Y_%m_%d_%H_%M')
+    # output_filename = 'code_sets_updated_' + date_str + '.csv'
+    # TODO: fix creates these columns depending on how we're doing indexing: Unnamed: 0	Unnamed: 0.1, etc
+    output_filename = 'code_sets.csv'
+    code_sets_df.to_csv(os.path.join(input_csv_folder_path, output_filename), index=False, encoding='utf-8')
+
+    return code_sets_df
+
+
+def _load_standardized_input_df(
+    path, integer_id_fields=['enclave_codeset_id', 'codeset_id', 'internal_id']
+) -> pd.DataFrame:
+    """Loads known input dataframe in a standardized way:
+        - Sets data types
+        - Fill na values"""
+    df: pd.DataFrame = pd.read_csv(path).fillna('')
+
+    # Strip: remove the spaces in the beginning and the end of the name
+    df.columns.str.lstrip()
+    df.columns.str.rstrip()
+
+    # Float->Int: For some reason, was being read with .0's at the end.
+    for field in [x for x in integer_id_fields if x in list(df.columns)]:
+        df[field] = pd.to_numeric(df[field], errors='coerce')\
+            .astype('Int64')
+
+    return df
+
+
+def load_cache_if_valid(input_csv_folder_path) -> Union[pd.DataFrame, None]:
+    """Checks `enclave_codeset_id` and, if no empty vals, uses this file as cache."""
+    df: pd.DataFrame = _load_standardized_input_df(os.path.join(input_csv_folder_path, 'code_sets.csv'))
+    ids = list(df['enclave_codeset_id'])
+    valid = not any([x == '' for x in ids])
+
+    return df if valid else None
+
+
+def left_join_update(df, df2):
+    """Does a left join, but where column names are the same, keeps right value if exists, else left value."""
+    new_df = df.merge(
+        df2, how='left', left_on='internal_id', right_on='codeset_id')
+
+    xy_col_counts: Dict[str, int] = {}
+    for col in list(new_df.columns):
+        if any([col.endswith(x) for x in ['_x', '_y']]):
+            common_col = col[:-2]
+            if common_col not in xy_col_counts:
+                xy_col_counts[common_col] = 0
+            xy_col_counts[common_col] += 1
+
+    xy_cols: List[str] = [k for k, v in xy_col_counts.items() if v == 2]
+    for col in xy_cols:
+        new_df[col] = new_df[col + '_y'].fillna(new_df[col + '_x'])
+        new_df = new_df.drop([col + '_x', col + '_y'], axis=1)
+
+    return new_df
+
+
+def persist_to_db(code_sets_df) -> pd.DataFrame:
+    """Save updated items to persistence layer"""
+    # Vars
+    join_col = 'codeset_id'
+    update_cols = ['enclave_codeset_id', 'enclave_codeset_id_updated_at', 'concept_set_name']
+
+    # Read
+    persistence_df = _load_standardized_input_df(CSET_UPLOAD_REGISTRY_PATH)
+
+    # Subset
+    try:
+        code_sets_df_limited = code_sets_df[[join_col] + update_cols]
+    except KeyError:  # if KeyError, `join_col` is an index
+        code_sets_df_limited = code_sets_df[update_cols]
+    # Join
+    persistence_df_new = left_join_update(persistence_df, code_sets_df_limited)
+
+    # Save and return
+    persistence_df_new.to_csv(CSET_UPLOAD_REGISTRY_PATH, index=False)
+    return persistence_df_new
+
+
+def _save_csv(
+    df: pd.DataFrame, out_format_name: str, in_format_name: str, inpath: str, output_filename: str,
+    field_delimiter=','
+):
+    """Side effects: Save CSV"""
+    # date_str = datetime.now().strftime('%Y.%m.%d')
+    # out_dir = os.path.join(UPLOADS_DIR, output_name, source_name, date_str, 'output')
+    infile_stem = os.path.basename(inpath).replace('.csv', '').replace('.tsv', '')
+    out_dir = os.path.join(UPLOADS_DIR, in_format_name, infile_stem, 'transforms', out_format_name)
+    os.makedirs(out_dir, exist_ok=True)
+    output_format = 'csv' if field_delimiter == ',' else 'tsv' if field_delimiter == '\t' else 'txt'
+    outpath = os.path.join(out_dir, f'{output_filename}.{output_format}')
+    df.to_csv(outpath, sep=field_delimiter, index=False)
+
+
+def update_cset_upload_registry_moffit(
+    moffit_path: str, registry_path: str = CSET_UPLOAD_REGISTRY_PATH
+) -> pd.DataFrame:
+    """Update concept set registry file, specifically for moffit entries.
+    Side effects: Writes update to registry file w/ any new entries"""
+    moffit_df = pd.read_csv(moffit_path).fillna('')
+    registry_df = pd.read_csv(registry_path).fillna('')
+    registered_moffit_cset_df = registry_df[registry_df['source_id_type'] == MOFFIT_SOURCE_ID_TYPE]
+    registered_moffit_ids = [str(x) for x in registered_moffit_cset_df['source_id']]
+    moffit_dataset_cset_ids: Set[str] = set([str(int(x)) for x in moffit_df['concept_set_id'].unique() if x != ''])
+    new_moffit_cset_ids: List = list(set([x for x in moffit_dataset_cset_ids if x not in registered_moffit_ids]))
+    try:  # integers if possible
+        new_moffit_cset_ids = [int(x) for x in new_moffit_cset_ids]
+    except TypeError:
+        pass
+    new_moffit_cset_ids.sort()
+
+    new_rows = []
+    next_internal_id: int = max(registry_df['internal_id']) + 1
+    for _id in new_moffit_cset_ids:
+        new_rows.append({
+            'source_id_type': 'moffit',
+            'source_id': _id,
+            # 'source_id_field': '',
+            # 'oid': '',
+            # 'ccsr_code': '',
+            'internal_id': next_internal_id,
+            'internal_source': MOFFIT_SOURCE_URL,
+            # 'cset_source': '',
+            # 'grouped_by_bids': '',
+            # 'concept_id': '',
+            # 'codeset_id': '',
+            # 'enclave_codeset_id': '',
+            # 'enclave_codeset_id_updated_at': '',
+            # 'concept_set_name': '',
+        })
+        next_internal_id += 1
+
+    if len(new_rows) > 0:
+        new_entries_df = pd.DataFrame(new_rows).fillna('')
+        new_registry_df = pd.concat([registry_df, new_entries_df]).fillna('')
+        new_registry_df.to_csv(registry_path, index=False)
+        return new_registry_df
+    return registry_df  # if no new updates
+
+
+# TODO: repurpose to moffit
+# TODO: Make sure all cols are being used
+def transform_moffit_to_palantir3file(inpath: str) -> str:
+    """Transform Moffit format to Palantir 3 File format."""
+    # Vars
+    field_delimiter = ','
+    out_format_name = 'palantir-three-file'
+    in_format_name = 'moffit'
+    out_filename1 = 'concept_set_version_item_rv_edited'
+    out_filename2 = 'code_sets'
+    out_filename3 = 'concept_set_container_edited'
+    infile_stem = os.path.basename(inpath).replace('.csv', '').replace('.tsv', '')
+    out_dir = os.path.join(UPLOADS_DIR, in_format_name, infile_stem, 'transforms', out_format_name)
+
+    # Read inputs
+    inpath = os.path.join(PROJECT_ROOT, inpath) if inpath.startswith('termhub-csets') else inpath
+    # df = pd.read_csv(inpath, converters={'concept_set_id': int}).fillna('')  # fails because one row has '' for id
+    df = pd.read_csv(inpath).fillna('')
+    df = df[df['concept_set_id'] != '']
+    df['concept_set_id'] = df['concept_set_id'].astype(int)
+    df['concept_set_id'] = df['concept_set_id'].astype(str)
+    df = df.applymap(lambda x: x.strip())
+    moffit_cset_ids: Set[str] = set([str(int(x)) for x in df['concept_set_id'].unique() if x])
+
+    # Read/update registry
+    cset_upload_registry_df: pd.DataFrame = update_cset_upload_registry_moffit(inpath)
+    registered_moffit_cset_df = cset_upload_registry_df[
+        cset_upload_registry_df['source_id_type'] == MOFFIT_SOURCE_ID_TYPE]
+    moffit_id_internal_id_map: Dict[str, str] = dict(zip(
+        [str(x) for x in registered_moffit_cset_df['source_id']],
+        [str(x) for x in registered_moffit_cset_df['internal_id']]))
+
+    # Transform
+    # II. Create & save exports
+    _all = {}
+    # 1. Palantir enclave table: concept_set_version_item_rv_edited
+    rows1 = []
+    codeset_id__code__map = {}
+    for i, concept_row in df.iterrows():
+        internal_id = moffit_id_internal_id_map[str(concept_row['concept_set_id'])]
+        code = concept_row['concept_code']
+        code_system = concept_row['code_system']
+
+        # This will help us avoid duplicate codes in single concept set
+        if internal_id not in codeset_id__code__map:
+            codeset_id__code__map[internal_id] = []
+        if code not in codeset_id__code__map[internal_id]:
+            codeset_id__code__map[internal_id].append(code)
+        else:
+            continue
+
+        # The 3 fields isExcluded, includeDescendants, and includeMapped, are from OMOP but also in VSAC. If it has
+        # ...these 3 options, it is intensional. And when you execute these 3, it is now extensional / expansion.
+        # todo: Don't need concept_name?
+        row = {
+            'codeset_id': internal_id,
+            'concept_id': '',  # leave blank for now
+            # <non-palantir fields>
+            'code': code,
+            'codeSystem': code_system,
+            # </non-palantir fields>
+            'isExcluded': False,
+            'includeDescendants': False,
+            'includeMapped': False,
+            'item_id': str(uuid4()),  # will let palantir verify ID is indeed unique
+            'annotation': f'Curated value set: {MOFFIT_PREFIX}',
+            # 'created_by': 'DI&H Bulk Import',
+            'created_by': PALANTIR_ENCLAVE_USER_ID_1,
+            'created_at': _datetime_palantir_format()
+        }
+        row2 = {}
+        for k, v in row.items():
+            row2[k] = v.replace('\n', ' - ') if type(v) == str else v
+        row = row2
+        rows1.append(row)
+    df_code_set_members = pd.DataFrame(rows1)
+    _all[out_filename1] = df_code_set_members
+    _save_csv(df_code_set_members, out_format_name, in_format_name, inpath, out_filename1, field_delimiter)
+
+    # 2. Palantir enclave table: code_sets
+    rows2 = []
+    for moffit_id in moffit_cset_ids:
+        v = 1
+        internal_id = moffit_id_internal_id_map[moffit_id]
+        cset_row = df[df['concept_set_id'] == moffit_id].iloc[0]
+        concept_set_name = f'[{MOFFIT_PREFIX}] ' + cset_row['concept_set_name']
+        row = {
+            'codeset_id': internal_id,
+            'concept_set_name': concept_set_name,
+            'concept_set_version_title': concept_set_name + f' (v{str(v)})',
+            'project': ENCLAVE_PROJECT_NAME,  # always use this project id for bulk import
+            'source_application': '',
+            'source_application_version': '',  # nullable
+            'created_at': _datetime_palantir_format(),
+            'atlas_json': '',  # nullable
+            'is_most_recent_version': True,
+            'version': v,
+            'comments': '',
+            'intention': '',  # nullable
+            'limitations': '',  # nullable
+            'issues': '',  # nullable
+            'update_message': 'Initial version.' if v == 1 else '',  # nullable (maybe?)
+            # status field stats as appears in the code_set table 2022/01/12:
+            # 'status': [
+            #     '',  # null
+            #     'Finished',
+            #     'In Progress',
+            #     'Awaiting Review',
+            #     'In progress',
+            # ][2],
+            # status field doesn't show this in stats in code_set table, but UI uses this value by default:
+            'status': 'Under Construction',
+            'has_review': '',  # boolean (nullable)
+            'reviewed_by': '',  # nullable
+            'created_by': PALANTIR_ENCLAVE_USER_ID_1,
+            'provenance': MOFFIT_SOURCE_URL,
+            'atlas_json_resource_url': '',  # nullable
+            # null, initial version will not have the parent version so this field would be always null:
+            'parent_version_id': '',  # nullable
+            # True ( after the import view it from the concept set editor to review the concept set and click done.
+            # We can add the comments like we imported from VSAC and reviewed it from the concept set editor. )
+            # 1. import 2. manual check 3 click done to finish the definition. - if we want to manually review them
+            # first and click Done:
+            'is_draft': True,
+        }
+        rows2.append(row)
+    df_code_sets = pd.DataFrame(rows2)
+    _all[out_filename2] = df_code_sets
+    _save_csv(df_code_sets, out_format_name, in_format_name, inpath, out_filename2, field_delimiter)
+
+    # 3. Palantir enclave table: concept_set_container_edited
+    rows3 = []
+    for moffit_id in moffit_cset_ids:
+        internal_id = moffit_id_internal_id_map[moffit_id]
+        cset_row = df[df['concept_set_id'] == moffit_id].iloc[0]
+        concept_set_name = f'[{MOFFIT_PREFIX}] ' + cset_row['concept_set_name']
+        row = {
+            'concept_set_id': internal_id,
+            'concept_set_name': concept_set_name,
+            'project_id': '',  # nullable
+            'assigned_informatician': PALANTIR_ENCLAVE_USER_ID_1,  # nullable
+            'assigned_sme': PALANTIR_ENCLAVE_USER_ID_1,  # nullable
+            'status': ['Finished', 'Under Construction', 'N3C Validation Complete'][1],
+            'stage': [
+                'Finished',
+                'Awaiting Editing',
+                'Candidate for N3C Review',
+                'Awaiting N3C Committee Review',
+                'Awaiting SME Review',
+                'Under N3C Committee Review',
+                'Under SME Review',
+                'N3C Validation Complete',
+                'Awaiting Informatician Review',
+                'Under Informatician Review',
+            ][1],
+            'intention': '',  # nullable
+            'n3c_reviewer': '',  # nullable
+            'alias': None,  # '' better?
+            'archived': False,
+            # 'created_by': 'DI&H Bulk Import',
+            'created_by': PALANTIR_ENCLAVE_USER_ID_1,
+            'created_at': _datetime_palantir_format()
+        }
+
+        row2 = {}
+        for k, v in row.items():
+            row2[k] = v.replace('\n', ' - ') if type(v) == str else v
+        row = row2
+
+        rows3.append(row)
+    df_code_sets__container_variation = pd.DataFrame(rows3)
+    _all[out_filename3] = df_code_sets__container_variation
+    _save_csv(df_code_sets__container_variation, out_format_name, in_format_name, inpath, out_filename3, field_delimiter)
+
+    return out_dir
+
+
+def run(input_path: str, format='palantir-three-file', use_cache=False):
+    """Main function"""
+    if format == 'moffit':
+        input_path = transform_moffit_to_palantir3file(input_path)
+    code_sets_df: Union[pd.DataFrame, None] = load_cache_if_valid(input_path) if use_cache else None
+    if code_sets_df is None:
+        code_sets_df: pd.DataFrame = post_to_enclave_and_update_code_sets_csv(input_path)
+    persist_to_db(code_sets_df)
+
+
+def cli():
+    """Command line interface for package.
+
+    Side Effects: Executes program."""
+    package_description = 'Tool for uploading to the Palantir Foundry enclave.'
+    parser = ArgumentParser(description=package_description)
+
+    parser.add_argument(
+        '-p', '--input-path',
+        help='Path to file or folder to be parsed and uploaded.')
+    parser.add_argument(
+        '-f', '--format',
+        choices=['palantir-three-file', 'moffit'],
+        default='palantir-three-file',
+        help='The format of the file(s) to be uploaded.\n'
+             '- palantir-three-file: Path to folder with 3 files that have specific columns that adhere to concept table data model. These '
+             'files must have the following names: i. `code_sets.csv`, ii. `concept_set_container_edited.csv`, iii. '
+             '`concept_set_version_item_rv_edited.csv`.\n'
+             '- moffit: Has columns concept_set_id, concept_set_name, concept_code, concept_name, code_system.')
+    # parser.add_argument(
+    #     '-c', '--use-cache',
+    #     action='store_true',
+    #     help='If present, will check the input file and look at the `enclave_codeset_id` column. If no empty values are'
+    #          ' present, this indicates that the `enclave_wrangler` has already been run and that the input file itself '
+    #          'can be used as cached data. The only thing that will happen is an update to the persistence layer, '
+    #          '(`data/cset.csv` as of 2022/03/18).'),
+    kwargs = parser.parse_args()
+    kwargs_dict: Dict = vars(kwargs)
+    run(**kwargs_dict)
+
+
+if __name__ == '__main__':
+    cli()

--- a/enclave_wrangler/enclave_api.py
+++ b/enclave_wrangler/enclave_api.py
@@ -1,0 +1,638 @@
+"""BulkImport VSAC Concept Sets and import them into the N3C Enclave using the API
+## APIs need to be called in the following order:
+## 1. Create new concept set container
+## 2. Create new draft version  -
+## Note, new draft version id must be generated within the range of 1,000,000,000, 1,001,000,000.
+## and used to add the CodeSystemExpressionItems
+## pre-generated ids is limited and it caused an issue in the Enclave the new process is as follows.
+## query for the id and use it in the addExpressionItems api
+## 3. Create CodeSystemExpression items - TBD
+
+Resources
+- Validate URL (for testing POSTs without it actually taking effect): https://unite.nih.gov/actions/api/actions/validate
+- Wiki article on how to create these JSON
+- https://github.com/National-COVID-Cohort-Collaborative/Data-Ingestion-and-Harmonization/wiki/BulkImportConceptSet-REST-APIs
+"""
+from typing import Any, Dict, List, Union
+
+import requests
+import json
+from enclave_wrangler.utils import log_debug_info
+
+# endpoint to post to create concept set
+API_CREATE_URL = 'https://unite.nih.gov/actions/api/actions'
+# Based on curl usage, it seems that '?synchronousPropagation=false' is not required but added here since it worked
+API_VALIDATE_URL = 'https://unite.nih.gov/actions/api/actions/validate?synchronousPropagation=false'
+API_QUERY_URL = 'https://unite.nih.gov/actions/api/actions/edits/'
+# example - https://unite.nih.gov/actions/api/actions/edits/ri.actions.main.action.f8ea6ccc-4035-4418-9dd3-d4d0f32ce396
+API_OBJECT_URL = 'https://unite.nih.gov/phonograph2/api/storage/load/objects/'
+
+DEBUG = True
+
+
+def key_val_split_list(list1):
+    key, val = list1.split(':')
+    return key, val
+
+
+def post_request_enclave_api_addExpressionItems(header: Dict, data_dict: Dict):
+    """
+    Uploads to:
+    https://unite.nih.gov/workspace/data-integration/dataset/preview/ri.foundry.main.dataset.e555b658-300c-48a3-9b3d-35cdbb9e2358/master
+    (above url) -> ConceptSetBulkImportCsvFiles/ -> writeback/
+
+    Does:
+    1. validate the request - no need to validate as it does not add benefit at this point
+    2. addCodeExpressionItems
+
+    Noes:
+    {'errorCode': 'INVALID_ARGUMENT', 'errorName': 'Conjure:UnprocessableEntity', 'errorInstanceId': '14a1177b-6431-40a4-92c2-714a2d8102b6', 'parameters': {}}
+    invalid argument error was fixed by
+    reply: 'HTTP/1.1 422 Unprocessable Entity\r\n'
+    validate before creating, not sure if this is extra step not adding any value at this point, ssh 2/16/22.
+    """
+    api_url = API_VALIDATE_URL
+    response = requests.post(api_url, data=json.dumps(data_dict), headers=header)
+    response_json = response.json()
+    if DEBUG:
+        log_debug_info()
+        print(response_json)  # temp
+    if 'type' not in response_json or response_json['type'] != 'validResponse':
+        raise SystemError(json.dumps(response_json, indent=2))
+
+    # if validResponse add the CodeExpressionItems
+    # add the code system expression items to draft cs version
+    # add the expression items for the specified version
+    api_url = API_CREATE_URL
+    print("request post: " + api_url)
+    response = requests.post(api_url, data=json.dumps(data_dict), headers=header)
+    response_json = response.json()
+    print("post request returned from addingCodeExpressionItems:  --------")
+    if DEBUG:
+        log_debug_info()
+        print(json.dumps(response_json))  # temp
+
+    return response_json
+
+
+def post_request_enclave_api_create_container(header: Dict, data_dict: Dict):
+    # validate the request
+    api_url = API_VALIDATE_URL
+    response = requests.post(api_url, data=json.dumps(data_dict), headers=header)
+    response_json = response.json()
+    if DEBUG:
+        log_debug_info()
+        print(response_json)  # temp
+    if 'type' not in response_json or response_json['type'] != 'validResponse':
+        raise SystemError(json.dumps(response_json, indent=2))
+
+    # TODO if validResponse is returned, create the container
+    api_url = API_CREATE_URL
+    response = requests.post(api_url, data=json.dumps(data_dict), headers=header)
+    response_json = response.json()
+    if DEBUG:
+        log_debug_info()
+        print(response_json)  # temp
+    # example error code - {'errorCode': 'INVALID_ARGUMENT',
+    # 'errorName': 'Actions:ObjectsAlreadyExist', 'errorInstanceId': 'deca8342-deb0-4f4c-8888-78b1e195d4dc',
+    # 'parameters': {'objectLocators': '[ObjectLocator{objectTypeId: omop-concept-set-container, primaryKey:
+    #  {concept_set_id=PrimaryKeyValue{value: StringWrapper{
+    #  value: [VSAC] Cirrhosis or other liver disease}}}}]'}}
+    # TODO if the container already exist than it is not an error so we should allow the next step.
+    # i.e. if the errorCode is invalid_argument and the errorName is 'Actions:ObjectsAlreadyExist'
+    #
+    if 'errorCode' in response_json and response_json['errorCode'] == 'INVALID_ARGUMENT' and response_json['errorName'] == 'Actions:ObjectsAlreadyExist':
+        return response_json
+
+    if 'actionRid' not in response_json and response_json['errorCode'] != '':
+        raise SystemError(json.dumps(response_json, indent=2))
+
+    return response_json
+
+
+# TODO
+# create version, it should return the action id
+# use the action id in the url to ask what effect creation app call had which should return
+#
+def post_request_enclave_api_create_version(header, cs_version_data_dict):
+    # create - skipping validate
+    codeset_id = 0
+    api_url = API_CREATE_URL
+    # data = json.dumps(cs_version_data_dict)
+    response = requests.post(api_url, data=json.dumps(cs_version_data_dict), headers=header)
+    response_json = response.json()
+    if DEBUG:
+        log_debug_info()
+        print(response_json)  # temp
+    # create the version - we can skip validation step, as previous version can exist
+    # if 'type' not in response_json or response_json['type'] != 'validResponse':
+    #    raise SystemError(json.dumps(response_json, indent=2))
+
+    # if validResponse then post call to create cs version
+    # The successful creation will return the following response
+    # {"actionRid":"ri.actions.main.action.f8ea6ccc-4035-4418-9dd3-d4d0f32ce396","synchronouslyPropagated":false}
+    # request get and ask what effect your create API call had with the following endpoint
+    # https://unite.nih.gov/actions/api/actions/edits/ri.actions.main.action.f8ea6ccc-4035-4418-9dd3-d4d0f32ce396
+    # the action rid must match the rid from the returned response from the create version post response
+
+    action_ridValue = response_json['actionRid']
+
+    # build the query endpoint url to ask for the details
+    api_url = API_QUERY_URL + action_ridValue
+    print("request get:: " + api_url)
+    # ask what effect your API call had. i.e. what edits it effected by calling the get
+    response = requests.get(api_url, headers=header)
+    # the get response should look something like the following:
+    response_json = response.json()
+    # i.e. the response should contain the objectRid
+    # {"objectEditLocators":
+    # [{"objectOrLinkRid":{"type":"objectRid","objectRid":"ri.phonograph2-objects.main.object.1b0ff201-e0e0-44f5-b7a6-950ed074cc7e"},
+    # "editsVersion":0,"editType":"ADD_OBJECT","maybeWorkstateMetadata":null}],"manyToManyLinkEditLocators":[]}
+    #
+    # objectEditLocators returns a list:
+    # {'objectOrLinkRid': {'type': 'objectRid', 'objectRid': 'ri.phonograph2-objects.main.object.725be25b-e7a5-467e-8764-aa1a9600d5b5'},
+    #  'editsVersion': 0,
+    # 'editType': 'ADD_OBJECT',
+    #  'maybeWorkstateMetadata': None}]
+
+    if 'objectEditLocators' in response_json:
+        objectEditLocatorsValue = response_json['objectEditLocators']
+        if DEBUG:
+            log_debug_info()
+            print(objectEditLocatorsValue)
+        # converting list to dictionary
+        # {'objectOrLinkRid': {'type': 'objectRid',
+        #                     'objectRid': 'ri.phonograph2-objects.main.object.440d160d-dd0a-4cf1-97d7-a243be4bd517'},
+        # 'editsVersion': 0, 'editType': 'ADD_OBJECT', 'maybeWorkstateMetadata': None}
+
+        # init dictionary with returned response values
+        # objectOrLinkRid values
+        resp_dict = dict(objectEditLocatorsValue[0])
+        if DEBUG:
+            log_debug_info()
+            print(resp_dict)
+
+        #init dictionary with objectOrLinkRid
+        # {'type': 'objectRid', 'objectRid': 'ri.phonograph2-objects.main.object.535d21a3-b7d2-4d40-9432-215d66b68da5'}
+        obj_dict = dict(resp_dict['objectOrLinkRid'])
+        if DEBUG:
+            log_debug_info()
+            print(obj_dict)
+
+        if DEBUG:
+            log_debug_info()
+            print("EnclaveAPI:: objectRid: " + str(obj_dict['objectRid']))
+
+        # get object rid so that the url can be built to request the cs version id
+        objectRidValue = obj_dict['objectRid']
+        # curl -X GET "https://unite.nih.gov/phonograph2/api/storage/load/objects/ri.phonograph2-objects.main.object.1b0ff201-e0e0-44f5-b7a6-950ed074cc7e"
+        # build the url using the object rid to get the codeset_id value
+        api_url = API_OBJECT_URL + objectRidValue
+        if DEBUG:
+            log_debug_info()
+            print("EnclaveAPI:: request get:: " + api_url)
+        response = requests.get(api_url, headers=header)
+        response_json = response.json()
+        # the response should contain the codeset_id
+        codeset_id_dict = dict(response_json['primaryKey'])
+        codeset_id = codeset_id_dict['codeset_id']
+        if DEBUG:
+            log_debug_info()
+            print("EnclaveAPI:: container version id, codeset_id: " + str(codeset_id))
+    # Need to use the codeset_id to add the cs expression items
+    # return the codeset_id
+    return codeset_id
+
+
+# 1/3. Create new concept set container (concept_set_container_edited.csv)
+# - 1 call per container
+# post request to call create the concept set container
+# CreateNewConceptSet rid =ri.actions.main.action-type.ef6f89de-d5e3-450c-91ea-17132c8636ae
+# 1. header should contain the authentication bearer token
+# 2. set actionTypeRid for the createNewConceptSet in the data
+# 3. set all parameter types and values in the data
+# Example, data = { “actionTypeRid”: “ri.actions.main.action-type.ef6f89de-d5e3-450c-91ea-17132c8636ae”,
+# for creating a new concept set container, need to set following parameters:
+# concept set name, intention, assigned informatician, assigned SME, status, stage, and Research Project
+# creatNewConceptSet
+# ri.actions.main.action-type.ef6f89de-d5e3-450c-91ea-17132c8636ae
+# concept set name (string) : ri.actions.main.parameter.1b5cd6e9-b220-4551-b97d-245b9fa86807
+# intention (string) : ri.actions.main.parameter.9e33b4d9-c7eb-4f27-81cd-152cc89f334b
+# assigned information (string):  ri.actions.main.parameter.28448734-2b6c-41e7-94aa-9f0d2ac1936f
+# assigned sme (string) : ri.actions.main.parameter.f04fd21f-4c97-4640-84e3-f7ecff9d1018
+# status (string whose value is always "Under Construction") : ri.actions.main.parameter.2b3e7cd9-6704-40a0-9383-b6c734032eb3
+# stage (string whose value is always "Awaiting Editing"): ri.actions.main.parameter.02dbf67e-0acc-43bf-a0a9-cc8d1007771b
+# Research Project (object) : ri.actions.main.parameter.a3eace19-c42d-4ff5-aa63-b515f3f79bdd
+# concept_set_name
+def get_cs_container_data(cs_name: str) -> Dict:
+    cs_container_data = {
+        "actionTypeRid": "ri.actions.main.action-type.ef6f89de-d5e3-450c-91ea-17132c8636ae",
+        "parameters": {
+            "ri.actions.main.parameter.1b5cd6e9-b220-4551-b97d-245b9fa86807": {
+                "type": "string",
+                "string": cs_name
+            },
+            "ri.actions.main.parameter.28448734-2b6c-41e7-94aa-9f0d2ac1936f": {
+                # informatician
+                "type": "string",
+                "string": "a39723f3-dc9c-48ce-90ff-06891c29114f"
+            },
+            "ri.actions.main.parameter.f04fd21f-4c97-4640-84e3-f7ecff9d1018": {
+                "null": {},
+                "type": "null"
+            },  # sme
+            "ri.actions.main.parameter.2b3e7cd9-6704-40a0-9383-b6c734032eb3": {
+                "string": "Under Construction",
+                "type": "string"
+            },
+            "ri.actions.main.parameter.02dbf67e-0acc-43bf-a0a9-cc8d1007771b": {
+                "string": "Awaiting Editing",
+                "type": "string"
+            },
+            "ri.actions.main.parameter.9e33b4d9-c7eb-4f27-81cd-152cc89f334b": {
+                "string": "Mixed",
+                "type": "string"
+            },
+            "ri.actions.main.parameter.a3eace19-c42d-4ff5-aa63-b515f3f79bdd": {
+                "objectLocator": {
+                    "objectTypeId": "research-project", "primaryKey": {
+                        "research_project_uid": {
+                            "string": "RP-4A9E27",
+                            "type": "string"
+                        }
+                    }
+                }, "type": "objectLocator"}}}
+    return cs_container_data
+
+
+## # cs_name, cs_id, intension, limitation, update_msg, status, provenance
+## TODO: utilize: cs_name, cs_id, pass in authority value when it becomes available in the codesets.csv
+def get_cs_version_data(cs_name, cs_id, intention, limitations, update_msg, provenance, authority):
+    """This code will be used to pass to 'action' endpoint, then it passes to this TypeScript function
+    which will create a modified object, pass it back to 'action', and 'action' will make the actual change:
+    https://unite.nih.gov/workspace/data-integration/code/repos/ri.stemma.main.repository.f4a40537-2187-46f4-ae90-c54ca36eb0c2/contents/f6a597efe3/functions-typescript/src/editor.ts
+    """
+
+    # Temp: Leaving this here for now as a static example of an attempt that actually worked today. - Joe 2022/02/02
+    #     return {
+    #     "actionTypeRid": "ri.actions.main.action-type.fb260d04-b50e-4e29-9d39-6cce126fda7f",
+    #     "parameters": {
+    #         "ri.actions.main.parameter.c3e857d9-a9d8-423c-9dec-610e4e90f971": {
+    #             "null": {},
+    #             "type": "null"
+    #         },
+    #         "ri.actions.main.parameter.51e12235-c217-47e2-a347-240d379434e8": {
+    #             "objectLocator": {
+    #                 "objectTypeId": "omop-concept-set-container",
+    #                 "primaryKey": {
+    #                     "concept_set_id": {
+    #                         "string": "stephanie test cs",
+    #                         "type": "string"
+    #                     }
+    #                 }
+    #             },
+    #             "type": "objectLocator"
+    #         },
+    #         "ri.actions.main.parameter.465404ad-c767-4d73-ab26-0d6e083eab8e": {
+    #             "objectLocator": {
+    #                 "objectTypeId": "research-project",
+    #                 "primaryKey": {
+    #                     "research_project_uid": {
+    #                         "string": "RP-4A9E27",
+    #                         "type": "string"
+    #                     }
+    #                 }
+    #             },
+    #             "type": "objectLocator"
+    #         },
+    #         "ri.actions.main.parameter.c58b7fa6-e6b4-49ad-8535-433507fe3d13": {
+    #             "null": {},
+    #             "type": "null"
+    #         },
+    #         "ri.actions.main.parameter.ae8b8a16-c690-42fa-b828-e60324074661": {
+    #             "string": "upd",
+    #             "type": "string"
+    #         },
+    #         "ri.actions.main.parameter.4e790085-47ed-41ad-b12e-72439b645031": {
+    #             "null": {},
+    #             "type": "null"
+    #         },
+    #         "ri.actions.main.parameter.5577422c-02a4-454a-97d0-3fb76425ba8c": {
+    #             "null": {},
+    #             "type": "null"
+    #         },
+    #         "ri.actions.main.parameter.2d5df665-6728-4f6e-83e5-8256551f8851": {
+    #             "type": "string",
+    #             "string": "Broad (sensitive)"
+    #         },
+    #         "ri.actions.main.parameter.32d1ce35-0bc1-4935-ad18-ba4a45e8113f": {
+    #             "null": {},
+    #             "type": "null"
+    #         },
+    #         "ri.actions.main.parameter.eac89354-a3bf-465e-a4be-bbf22a6e2c50": {
+    #             "null": {},
+    #             "type": "null"
+    #         }
+    #     }
+    # }
+
+    # TODO: We should add a quality control check:
+    #  If any of the values passed are null/None, need to do "type": "null" and "null": {} instead of  e.g. "string"
+    #  ...Amin said this is only needed for optional params.
+    cs_version_data = {
+        "actionTypeRid": "ri.actions.main.action-type.fb260d04-b50e-4e29-9d39-6cce126fda7f",
+        "parameters": {
+            # ID: range(1billion, 1.1billion; non-inclusive) (optional)
+            # TODO: We had success by nullifying this. Amin told us that our integer ID looks good,
+            #  ...but they're still seeing an error on their end, so he's looking into it. - Joe 2022/02/02
+            # pass in as a string
+            # TODO: method changed - Stephanie 2/4/2022
+            # enclave is still having error passing in the codeset_id.
+            # work around is for us to query the id after the draft version is created.
+            "ri.actions.main.parameter.eac89354-a3bf-465e-a4be-bbf22a6e2c50": {
+                # "type": "integer",
+                # "integer ": 1000000001
+                "type": "null",
+                "null": {}
+                # enclave generated this id when a draft version is created, so we have to query for this id value
+                # there was an issue when passing in the integer type as an id failed due to unknown issue in the Enclave
+                # note: 2/4/ 2022
+                # "type": "integer",
+                # "integer": cs_id - passing in cs_id did not work
+            },  # reserved id list from DI&H id bank, cannot be reused
+            # 3/14/22 Stephanie - revised method is to query for the id and use the id from the enclave
+
+            "ri.actions.main.parameter.51e12235-c217-47e2-a347-240d379434e8": {
+                "type": "objectLocator",
+                "objectLocator": {
+                    "objectTypeId": "omop-concept-set-container",
+                    "primaryKey": {
+                        "concept_set_id": {
+                            "type": "string",
+                            # Amin asked us to use this instead:
+                            # "string": "stephanie cs example"
+                            # "string": "stephanie test cs"
+                            # cs contain name generated from VSAC
+                            "string": cs_name
+                            # 2/7/22, steph- using test cs until we can validate all three calls are working
+                            # "string": "stephanie test cs"
+                        }
+                    }
+                }
+            },  # cs_name must match the string from the container
+            # Current maximum version (deprecated):
+            # - In the ConceptSetEditor GUI, maximum version is passed in. But in the case where
+            # ...we're creating the first version, this can be null.
+            "ri.actions.main.parameter.c58b7fa6-e6b4-49ad-8535-433507fe3d13": {
+                "null": {},
+                "type": "null"
+                # "double": 0,
+                # "type": "double"
+            },
+            # Actual object concept version (starting from) (optional):
+            # - Logic is that you might create a new version. This is the parent version.
+            # - If "current max version" is null, this needs to be null. This param is required to be non-null if
+            # ...and only if "current max version" is not null.
+            "ri.actions.main.parameter.c3e857d9-a9d8-423c-9dec-610e4e90f971": {
+                "null": {},
+                "type": "null"
+            },
+            # Update message (optional; deprecated):
+            "ri.actions.main.parameter.ae8b8a16-c690-42fa-b828-e60324074661": {
+                "type": "string",
+                # "string": update_msg
+                # use the provenance text for the update_msg - due to the current UI functionality - 3/11/22 shong
+                "string": provenance
+            },
+            # Intention:
+            "ri.actions.main.parameter.2d5df665-6728-4f6e-83e5-8256551f8851": {
+                "type": "string",
+                "string": intention
+            },
+            # Limitations:
+            "ri.actions.main.parameter.32d1ce35-0bc1-4935-ad18-ba4a45e8113f": {
+                "type": "string",
+                "string": limitations
+            },
+            # Provenance:
+            # ri.actions.main.parameter.5577422c-02a4-454a-97d0-3fb76425ba8c
+            "ri.actions.main.parameter.5577422c-02a4-454a-97d0-3fb76425ba8c": {
+                "type": "string",
+                "string": provenance
+            },
+            # Research project (1 of: [DomainTeam || ResearchProject] = required):
+            "ri.actions.main.parameter.465404ad-c767-4d73-ab26-0d6e083eab8e": {
+                "objectLocator": {
+                    "objectTypeId": "research-project",
+                    "primaryKey": {
+                        "research_project_uid": {
+                            "type": "string",
+                            "string": "RP-4A9E27"
+                        }
+                    }
+                }, "type": "objectLocator"
+            },
+            # Domain team (1 of: [DomainTeam || ResearchProject] = required):
+            "ri.actions.main.parameter.4e790085-47ed-41ad-b12e-72439b645031": {
+                "null": {},
+                "type": "null"
+            },  # domainTeam, optional only if research_id is submitted
+            "ri.actions.main.parameter.f6766c2d-79a6-445f-a664-d245e1abf199": {
+                "type": "string",
+                "string": authority
+            }  # authority source
+        }
+    }
+    return cs_version_data
+
+
+### 2/3. createNewDraftConceptSetVersion()
+def post_cs_container(cs_name, token):
+    """create a concept set container """
+    url = f'https://unite.nih.gov/actions/api/actions'
+    my_header = f'Authentication: Bearer {token}'
+    container_data = get_cs_container_data(cs_name)
+    response = requests.post(url, headers=my_header, data=container_data)
+    r = response.json()
+    return r
+
+
+### 2/3. createNewDraftConceptSetVersion() (CreateNewConceptSet: concept_set_container_edited.csv)
+
+# - 1 call per version
+### data for creating a new draft version of the concept set - we will always be creating a version 1
+### actionTypeRid: ri.actions.main.action-type.fb260d04-b50e-4e29-9d39-6cce126fda7f
+### parameters :
+### concept_set_container object (object) ri.actions.main.parameter.51e12235-c217-47e2-a347-240d379434e8
+### current max version number (integer) : ri.actions.main.parameter.c58b7fa6-e6b4-49ad-8535-433507fe3d13
+### version to start with (object) :ri.actions.main.parameter.c3e857d9-a9d8-423c-9dec-610e4e90f971
+### update message (string) : ri.actions.main.parameter.ae8b8a16-c690-42fa-b828-e60324074661
+### intention (string): ri.actions.main.parameter.2d5df665-6728-4f6e-83e5-8256551f8851
+### limitations (string) : ri.actions.main.parameter.32d1ce35-0bc1-4935-ad18-ba4a45e8113f
+### provenance (string) ri.actions.main.parameter.5577422c-02a4-454a-97d0-3fb76425ba8c
+### intended research project (object): ri.actions.main.parameter.465404ad-c767-4d73-ab26-0d6e083eab8e
+### domain team (object) : ri.actions.main.parameter.4e790085-47ed-41ad-b12e-72439b645031
+# TODO: Amin said on 2022/01/28:
+# hey foks, the create new version API call now has a new parameter that you will need to provide - the concept set version id of the version you're creating. You're responsible for its uniqueness, and you have a reserved range.
+# Its id is  ri.actions.main.parameter.eac89354-a3bf-465e-a4be-bbf22a6e2c50
+# and it's an integer in the following range: (1,000,000,000, 1,001,000,000).
+
+cs_version_create_data = {
+    "actionTypeRid": "ri.actions.main.action-type.fb260d04-b50e-4e29-9d39-6cce126fda7f",
+    "parameters": {
+        "ri.actions.main.parameter.51e12235-c217-47e2-a347-240d379434e8": {
+            "type": "objectLocator",
+            "objectLocator": {
+                "objectTypeId": "omop-concept-set-container",
+                "primaryKey": {
+                    "concept_set_id": {
+                        "type": "string",
+                        "string": "<must match the concept name string specified in the container creation>"
+                    }
+                }
+            },
+            "ri.actions.main.parameter.c58b7fa6-e6b4-49ad-8535-433507fe3d13": {
+                "type": "integer",
+                "integer": 1,
+            },
+            "ri.actions.main.parameter.c3e857d9-a9d8-423c-9dec-610e4e90f971": {
+                "type": "objectLocator",
+                "objectLocator": {
+                    "objectTypeId": "version_id",
+                    "primaryKey": {
+                        "version_id": {
+                            "type": "integer",
+                            "integer": 1
+                        }
+                    }
+                }
+            },
+            "ri.actions.main.parameter.ae8b8a16-c690-42fa-b828-e6032-4074661": {
+                "type": "string",
+                "string": "Initial [VSAC] version"
+            },
+            "ri.actions.main.parameter.2d5df665-6728-4f6e-83e5-8256551f8851": {
+                "type": "string",
+                "string": "<intension string build from vsac source is set here>"
+            },
+            "ri.actions.main.parameter.32d1ce35-0bc1-4935-ad18-ba4a45e8113f": {
+                "type": "string",
+                "string": "<limitations text from vsac source is set here>"
+            },
+            "ri.actions.main.parameter.5577422c-02a4-454a-97d0-3fb76425ba8c": {
+                "type": "string",
+                "string": "<provenance built from the VSAC source is set here>"
+            },
+            "ri.actions.main.parameter.465404ad-c767-4d73-ab26-0d6e083eab8e": {
+                "type": "objectLocator",
+                "objectLocator": {
+                    "objectTypeId": "research-project",
+                    "primaryKey": {
+                        "research_project_uid": {
+                            "type": "string",
+                            "string": "RP-4A9E27"
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+
+### 3/3. add-code-system-codes-as-omop-version-expressions
+# - bulk call for a single concept set; may contain many expressions in one call.
+# can only do 1 concept set version per post request
+# new api that will accept a codes and codeSystem instead of the concept_ids
+# ri for he api that addsCodeExpressionItem
+# ri.actions.main.action-type.e07f2503-c7c9-47b9-9418-225544b56b71
+# version id generated when draft version is created.
+# send get request to query for the codeset_id
+# concept_set_version_item_rv_edited.csv
+### 3/3. createCodeSystemConceptVersionExpressionItems (addCodeAsVersionExpression: concept_set_version_item_rv_edited.csv)
+# - bulk call for a single concept set; can contain many expressions in one call.
+#  can only do 1 concept set per call
+# domain team (object) : ri.actions.main.parameter.4e790085-47ed-41ad-b12e-72439b645031 is an
+# optional parameter, not need to send if research project is set
+# codeset_id is added as a variable which we can replace with actual codeset_id returned from the Enclave
+#
+def get_cs_version_expression_data(current_code_set_id: Union[str, int], cs_name: str, code_list: List[str],
+        bExclude: bool, bDescendents: bool, bMapped: bool, annotation: str) -> Dict[str, Any]:
+    cs_version_expression_data = {
+        "actionTypeRid": "ri.actions.main.action-type.e07f2503-c7c9-47b9-9418-225544b56b71",
+        "parameters": {
+            # Version (object type): id used in version creation should be used
+            "ri.actions.main.parameter.ad298972-0db3-4d85-9bbc-0c9ecd6ecf01": {
+                "type": "objectLocator",
+                "objectLocator": {
+                    "objectTypeId": "omop-concept-set",
+                    "primaryKey": {
+                        "codeset_id": {
+                            "type": "integer",
+                            # "integer": current_code_set_id
+                            # call the api to find out want draft version was created to and ask for the ID
+                            # and pass that number here
+                            # "integer": 671112503 draftversion id from Amin
+                            #"integer": 462280913  # id from create version api call
+                            "integer": "$codeset_id"
+                        }
+                    }
+                }
+            },
+            # Exclude (boolean type):
+            # ri.actions.main.parameter.4a7ac14f-b292-4105-b7f5-5d0817b8cdc4
+            "ri.actions.main.parameter.4a7ac14f-b292-4105-b7f5-5d0817b8cdc4": {
+                "type": "boolean",
+                "boolean": bExclude
+            },
+
+            # Include Descendents (boolean type):
+            # ri.actions.main.parameter.6cb950fd-894d-4176-9ad5-080373e26777
+            "ri.actions.main.parameter.6cb950fd-894d-4176-9ad5-080373e26777": {
+                "type": "boolean",
+                # "boolean": bDescendents
+                "boolean": bDescendents
+            },
+
+            # Include Mapped (boolean type):
+            # ri.actions.main.parameter.1666c70c-0cb8-47c0-91e5-cb1d7e5bf316
+            "ri.actions.main.parameter.1666c70c-0cb8-47c0-91e5-cb1d7e5bf316": {
+                "type": "boolean",
+                "boolean": bMapped
+            },
+
+            # Optional Annotation (string | null type):
+            # ri.actions.main.parameter.63e31a99-6b94-4580-b95a-a482ed64fed0
+            "ri.actions.main.parameter.63e31a99-6b94-4580-b95a-a482ed64fed0": {
+                # "null": {},
+                # "type": "null"
+                "type": "string",
+                "string": annotation
+
+            },
+
+            # Codes (List of colon-delimited strings):
+            # ri.actions.main.parameter.c9a1b531-86ef-4f80-80a5-cc774d2e4c33
+            "ri.actions.main.parameter.c9a1b531-86ef-4f80-80a5-cc774d2e4c33": {
+                "type": "stringList",
+                "stringList": {
+                    "strings":
+                     code_list
+                    # TODO -following test code list worked, testcase, replace with code_list
+                    # ["SNOMEDCT:253811003", "ICD10CM:K76.5", "ICD10CM:K76.6"]
+                }
+            }
+        }
+    }
+    return cs_version_expression_data
+
+def update_cs_version_expression_data_with_codesetid(cs_version_id, cs_version_expression_items_dict):
+    cs_version_id_str = str(cs_version_id)
+    if DEBUG:
+        log_debug_info()
+        print(json.dumps(cs_version_expression_items_dict))
+    cs_version_expression_items_dict = json.loads(json.dumps(cs_version_expression_items_dict).replace('"$codeset_id"', cs_version_id_str ))
+    if DEBUG:
+        log_debug_info()
+        print(json.dumps(cs_version_expression_items_dict))
+    return cs_version_expression_items_dict

--- a/enclave_wrangler/utils.py
+++ b/enclave_wrangler/utils.py
@@ -1,5 +1,6 @@
 """Extra utilities"""
 import logging
+from datetime import datetime, timezone
 from http.client import HTTPConnection
 import contextlib
 
@@ -35,3 +36,9 @@ def debug_requests_off():
     requests_log = logging.getLogger("requests.packages.urllib3")
     requests_log.setLevel(logging.WARNING)
     requests_log.propagate = False
+
+
+def _datetime_palantir_format() -> str:
+    """Returns datetime str in format used by palantir data enclave
+    e.g. 2021-03-03T13:24:48.000Z (milliseconds allowed, but not common in observed table)"""
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S.%fZ")[:-4] + 'Z'


### PR DESCRIPTION
Updates
```
    Enclave Wrangler
    - Update: Utils: Added palantire datetime function
    - Add: dataset_upload.py: For uploading datasets to Foundry
    - Add: enclave_api.py: Lower level functions for working directly with the Foundry REST API.
    - Add: Transformation code to go from Moffit format to the Foundry common dataset format.
    - Add: .run/ config for moffit dataset

    Termhub csets
    - Update to include new dirs/files
```