### PR TITLE
Documentation: atlas json

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,3 +119,30 @@ SET search_path TO n3c;
 
 ### Database management
 Refer to the [developer docs](./docs/developer.md) for more information.
+
+## Using TermHub
+### How to make changes to a codeset (via Atlas JSON)
+1. Go to the "Cset Search" page.
+2. Search for the codeset.
+3. Select the codeset from the dropdown menu.
+4. Optional: Select any additional codesets that might also be helpful in the process, e.g. to compare to the one we are editing.
+5. Go to the "Cset Comparison" page.
+6. Click on the column header for codeset you want to change.
+  - Click <b>+</b> to add a concept
+  - Click the <b>cancel sign</b> to remove a concept
+  - Click <b>D</b> to toggle <code>inludeDescendants</code>
+  - Click <b>M</b> to toggle <code>includeMapped</code>
+  - Click <b>X</b> to toggle <code>isExcluded</code>
+7. You will see two boxes at the top. The left box has some metadata about the codeset. The right box shows your <em>staged changes</em>. Click the <b>Export JSON</b> link in that <em>staged changes</em> box.
+8. A new browser tab will up with just the JSON. Copy or save it.
+9. Go back to the "Cset Comparison" page, and click the "Open in Enclave" link.
+10. A new tab for the N3C data enclave will open. Log in if needed.
+11. Click the "Versions" tab at the top left.
+12. Click the blue "Create new version" button at the bottom left.
+13. Fill out the information in the "Create New Draft OMOP Concept Set Version" popup, and click "Submit".
+14. Your new draft version should appear on the left (may require a page refresh). Click it.
+15. On the right hand side, there is a blue button called "Add Concepts". Click the down arrow, then select "Import ATLAS Concept Set Expression JSON" from the menu.
+16. Copy/paste the JSON obtained from TermHub earlier into the box, and click "Import Atlas JSON".
+17. Click the version on the left again.
+18. On the right, click the green "Done" button.
+

--- a/frontend/src/AboutPage.js
+++ b/frontend/src/AboutPage.js
@@ -10,6 +10,10 @@ import {Link} from "@mui/material";
 // import {Table} from './Table';
 // import {cfmt} from "./utils";
 
+let TextBody = (props) => (<Typography variant="body2" color="text.primary" gutterBottom>{props.children}</Typography>)
+let TextH1 = (props) => (<Typography variant="h5" color="text.primary" style={{marginTop: '22px'}} gutterBottom>{props.children}</Typography>)
+let TextH2 = (props) => (<Typography variant="h6" color="text.primary" style={{marginTop: '5px'}} gutterBottom>{props.children}</Typography>)
+
 function AboutPage(props) {
   // const {codeset_ids=[], all_csets=[], cset_data={}} = props;
   // const {data_counts=[], } = cset_data;
@@ -24,30 +28,54 @@ function AboutPage(props) {
 
   return (
       <div>
-        <Typography variant="h5" color="text.primary" gutterBottom>
-          About TermHub
-        </Typography>
-        <Typography variant="body2" color="text.primary" gutterBottom>
-          <p>TermHub is a tool for creating and updating concept sets. <a href="https://youtu.be/EAwBZUiNUUk?t=2130">Demo video</a>.</p>
-        </Typography>
+        <TextH1>About TermHub</TextH1>
+        <TextBody>TermHub is a tool for creating and updating concept sets. <a href="https://youtu.be/EAwBZUiNUUk?t=2130">Demo video</a>.</TextBody>
         
-        <Typography variant="h5" color="text.primary" gutterBottom>
-          Bug reports & feature requests
-        </Typography>
-        <Typography variant="body2" color="text.primary" gutterBottom>
-          If you encounter a bug or a poor user experience issue, or have a feature request in mind, we would love to hear from you.
+        <TextH1>Bug reports & feature requests</TextH1>
+        <TextBody>
+          If you encounter a bug or a poor user experience issue, or have a feature request in mind, we would love to hear from you.<br/>
           {/*<p><Button variant={"outlined"}>*/}
-            <p><Button variant={"contained"}>
-            {/*<a href="https://github.com/jhu-bids/TermHub/issues/new/choose"></a>Create an issue*/}
-<Link href="https://github.com/jhu-bids/TermHub/issues/new/choose" color="inherit">
-  Create an issue
-</Link>
-          </Button></p>
-          
-        </Typography>
+          <Button variant={"contained"}><Link href="https://github.com/jhu-bids/TermHub/issues/new/choose" color="inherit">
+            Create an issue
+          </Link></Button>
+        </TextBody>
         
-        {/*<Table rowData={rowData}/>*/}
-
+        <TextH1>How to's</TextH1>
+        <TextH2>How to make changes to a codeset (via Atlas JSON)</TextH2>
+        {/*todo: resolve console warnings: <ul>/<ol> cannot appear as a descendant of <p>.
+            https://mui.com/material-ui/api/typography/*/}
+        <TextBody>
+          <ol>
+            <li>Go to the "Cset Search" page.</li>
+            <li>Search for the codeset.</li>
+            <li>Select the codeset from the dropdown menu.</li>
+            <li>Optional: Select any additional codesets that might also be helpful in the process, e.g. to compare to the one we are editing.</li>
+            <li>Go to the "Cset Comparison" page.</li>
+            <li>Click on the column header for codeset you want to change.</li>
+              <ul>
+                <li>Click <b>+</b> to add a concept</li>
+                <li>Click the <b>cancel sign</b> to remove a concept</li>
+                <li>Click <b>D</b> to toggle <code>inludeDescendants</code></li>
+                <li>Click <b>M</b> to toggle <code>includeMapped</code></li>
+                <li>Click <b>X</b> to toggle <code>isExcluded</code></li>
+              </ul>
+            <li>You will see two boxes at the top. The left box has some metadata about the codeset. The right box shows your <em>staged changes</em>. Click the <b>Export JSON</b> link in that <em>staged changes</em> box.</li>
+            <li>A new browser tab will up with just the JSON. Copy or save it.</li>
+            <li>Go back to the "Cset Comparison" page, and click the "Open in Enclave" link.</li>
+            <li>A new tab for the N3C data enclave will open. Log in if needed.</li>
+            <li>Click the "Versions" tab at the top left.</li>
+            <li>Click the blue "Create new version" button at the bottom left.</li>
+            <li>Fill out the information in the "Create New Draft OMOP Concept Set Version" popup, and click "Submit".</li>
+            <li>Your new draft version should appear on the left (may require a page refresh). Click it.</li>
+            <li>On the right hand side, there is a blue button called "Add Concepts". Click the down arrow, then select "Import ATLAS Concept Set Expression JSON" from the menu.</li>
+            <li>Copy/paste the JSON obtained from TermHub earlier into the box, and click "Import Atlas JSON".</li>
+            <li>Click the version on the left again.</li>
+            <li>On the right, click the green "Done" button.</li>
+          </ol>
+        </TextBody>
+        
+        {/* todo: Pages */}
+        
       </div>
   );
 }

--- a/frontend/src/ConceptSetCard.js
+++ b/frontend/src/ConceptSetCard.js
@@ -171,7 +171,10 @@ function ConceptSetCard(props) {
             ))
           }
           <Typography variant="body2" color="text.primary" >
-            <a href={`https://unite.nih.gov/workspace/hubble/external/object/v0/omop-concept-set?codeset_id=${cset.codeset_id}`} target="_blank" rel="noreferrer">Open in Enclave</a
+            {/*This link opens the version */}
+            {/*<a href={`https://unite.nih.gov/workspace/hubble/external/object/v0/omop-concept-set?codeset_id=${cset.codeset_id}`} target="_blank" rel="noreferrer">Open in Enclave</a*/}
+            {/*This link opens the container */}
+            <a href={`https://unite.nih.gov/workspace/hubble/objects/${cset.container_rid}`} target="_blank">Open in Enclave</a
             >, <a href={backend_url(`cset-download?codeset_id=${cset.codeset_id}`)} target="_blank" rel="noreferrer">Export JSON</a>
           </Typography>
           { researcherContent }


### PR DESCRIPTION
Updates
```
Documentation
- About page: Refactored to add some simple components
- About page: Added how to about uploading Atlas JSON
- README.md: Added same content as done in 'About page'

Frontend
- About page: docs as described above
- Concept set comparison page: Concept version selected box: the "open in enclave" button now opens the container in the Enclave again. This was done so that there would be less steps people would need to take when uploading Atlas JSON.
```