### PR TITLE
DB Counts updates

### DIFF
--- a/backend/db/analysis.py
+++ b/backend/db/analysis.py
@@ -8,6 +8,7 @@ from pprint import pprint
 from typing import Dict, List
 import dateutil.parser as dp
 import pandas as pd
+from pandas import Series
 
 THIS_DIR = os.path.dirname(__file__)
 PROJECT_ROOT = Path(THIS_DIR).parent.parent
@@ -15,7 +16,11 @@ sys.path.insert(0, str(PROJECT_ROOT))
 from backend.db.initialize import SCHEMA
 from backend.db.utils import get_db_connection, insert_from_dict, list_tables, run_sql
 
-COUNTS_OVER_TIME_OPTIONS = ['print_counts_table', 'print_delta_table', 'save_delta_viz']
+COUNTS_OVER_TIME_OPTIONS = [
+    'print_counts_table',
+    'print_delta_table',
+    # 'save_delta_viz'
+]
 
 
 # TODO: automatically compare to most recent backup. currently fixed to a specific schema
@@ -58,21 +63,37 @@ def counts_compare_schemas(
     return result
 
 
-def counts_update(schema: str = SCHEMA, local=False):
-    """Update 'counts' table with current row counts."""
+def counts_update(note: str, schema: str = SCHEMA, local=False):
+    """Update 'counts' table with current row counts.
+
+    :param note: For context around what was going on around when / why the counts are updated, e.g. after a backup or
+    a data fetch from the enclave, or after editing a batch of concept sets.
+    """
     dt = datetime.now()
+    # Fetch current tables
     with get_db_connection(schema=schema, local=local) as con:
         tables: List[str] = list_tables(con)
+    # DB updates
     with get_db_connection(schema='', local=local) as con:
+        # Save run metadata, e.g. a note about it
+        insert_from_dict(con, 'counts_runs', {
+            'timestamp': str(dt),
+            'date': dt.strftime('%Y-%m-%d'),
+            'schema': schema,
+            'note': note,
+        })
+        # Save row counts
         timestamps: List[datetime] = [dp.parse(x[0]) for x in run_sql(con, f'SELECT DISTINCT timestamp from counts;')]
         most_recent_timestamp: str = str(max(timestamps))
         prev_counts: List[Dict] = [dict(x) for x in run_sql(con, f'SELECT * from counts;')]
         prev_counts_df = pd.DataFrame(prev_counts)
         for table in tables:
             count: int = [x for x in run_sql(con, f'SELECT COUNT(*) from n3c.{table};')][0][0]
-            last_count = int(prev_counts_df[
+            last_count_fetch: Series = prev_counts_df[
                 (prev_counts_df['timestamp'] == most_recent_timestamp) &
-                (prev_counts_df['table'] == table)]['count']) if prev_counts else count
+                (prev_counts_df['table'] == table)]['count']
+            last_count_fetch2: List[int] = list(last_count_fetch.to_dict().values())
+            last_count: int = int(last_count_fetch2[0]) if prev_counts and last_count_fetch2 else 0
             insert_from_dict(con, 'counts', {
                 'date': dt.strftime('%Y-%m-%d'),
                 'timestamp': str(dt),
@@ -83,18 +104,35 @@ def counts_update(schema: str = SCHEMA, local=False):
             })
 
 
+# TODO: support multiple schema
 def counts_over_time(
     schema: str = SCHEMA, local=False, method=COUNTS_OVER_TIME_OPTIONS[0]
 ):
     """Checks counts of database and store what the results look like in a database over time"""
+    if method not in COUNTS_OVER_TIME_OPTIONS:
+        raise ValueError(f'counts_over_time(): Invalid method {method}. Must be one of {COUNTS_OVER_TIME_OPTIONS}')
     with get_db_connection(schema='', local=local) as con:
+        # Get counts
         counts: List[Dict] = [dict(x) for x in run_sql(con, f'SELECT * from counts;')]
         counts_df = pd.DataFrame(counts)
         counts_df = counts_df[counts_df['schema'] == schema]
         values = 'count' if method == 'print_counts_table' else 'delta'
-        df = counts_df.pivot(index='table', columns='timestamp', values=values)
-        if method == 'save_delta_viz':  # TODO
-            pass
+        data_df = counts_df.pivot(index='table', columns='timestamp', values=values).fillna(0).astype(int)
+        # Add note
+        # todo
+        runs = [dict(x) for x in run_sql(con, f'SELECT timestamp, note from counts_runs;')]
+        timestamps = [x['timestamp'] for x in runs]
+        ts_dict = {}
+        for ts in timestamps:
+            for run in runs:
+                if run['timestamp'] == ts:
+                    ts_dict[ts] = run['note']
+        runs_df = pd.DataFrame([ts_dict])
+        runs_df.index = ['COMMENT']
+        df = pd.concat([runs_df, data_df])
+        # Print / save
+        if method == 'save_delta_viz':
+            raise NotImplementedError('Option save_delta_viz for counts_over_time() not yet implemented.')
         else:
             print(df)
 
@@ -103,22 +141,36 @@ def cli():
     """Command line interface."""
     parser = ArgumentParser(prog='TermHub DB analysis utils.', description='Various analyses for DB.')
     parser.add_argument(
-        '-c', '--counts-compare-schemas', action='store_true',
+        '-s', '--counts-compare-schemas', action='store_true',
         help="Checks counts of database tables for the current 'n3c' schema and its most recent backup.")
+    parser.add_argument(
+        '-c', '--counts-over-time', action='store_true',
+        help="View counts row counts over time for the 'n3c' schema.")
+    parser.add_argument(
+        '-d', '--deltas-over-time', action='store_true',
+        help="View row count deltas over time for the 'n3c' schema.")
     parser.add_argument(
         '-u', '--counts-update', action='store_true',
         help="Update 'counts' table with current row counts for the 'n3c' schema.")
     parser.add_argument(
-        '-t', '--counts-over-time', choices=COUNTS_OVER_TIME_OPTIONS,
-        help="View counts row counts over time for the 'n3c' schema.")
+        '-n', '--note',
+        help="Only used with `--counts-update`. Add a note to the 'counts-runs' table.")
 
     d: Dict = vars(parser.parse_args())
-    if d['counts_compare_schemas']:
-        counts_compare_schemas()
     if d['counts_update']:
-        counts_update()
-    if d['counts_over_time']:
-        counts_over_time(method=d['counts_over_time'])
+        note = d['note'].strip()
+        if not note:
+            print('Error: Must provide a --note when using --counts-update.', file=sys.stderr)
+        else:
+            counts_update(note)
+    elif d['counts_compare_schemas']:
+        counts_compare_schemas()
+    elif d['counts_over_time']:
+        counts_over_time(method='print_counts_table')
+    elif d['deltas_over_time']:
+        counts_over_time(method='print_delta_table')
+    else:
+        print('Error: Choose an option. Can see available options by running with --help', file=sys.stderr)
 
 
 if __name__ == '__main__':

--- a/backend/db/initialize.py
+++ b/backend/db/initialize.py
@@ -33,7 +33,21 @@ def create_database(con: Connection, schema: str):
         # noinspection PyUnresolvedReferences
         con.connection.connection.set_isolation_level(1)
     with get_db_connection(schema='') as con2:
-        run_sql(con2, "CREATE TABLE IF NOT EXISTS public.manage (key text not null, value text);")
+        run_sql(con2, "CREATE TABLE IF NOT EXISTS public.manage ("
+                      "key text not null, "
+                      "value text);")
+        run_sql(con2, "CREATE TABLE IF NOT EXISTS public.counts ("
+                      "timestamp text not null, "
+                      "date text, "
+                      "schema text not null, "
+                      '"table" text not null, '
+                      "count integer not null, "
+                      "delta integer not null);")
+        run_sql(con2, "CREATE TABLE IF NOT EXISTS public.counts_runs ("
+                      "timestamp text not null, "
+                      "date text, "
+                      "schema text not null, "
+                      "note text);")
         run_sql(con, f'CREATE SCHEMA IF NOT EXISTS {schema};')
 
 

--- a/backend/db/utils.py
+++ b/backend/db/utils.py
@@ -17,7 +17,7 @@ from typing import Any, Dict, Union, List
 
 from backend.db.config import CONFIG, DATASETS_PATH, OBJECTS_PATH, get_pg_connect_url
 from backend.utils import commify
-from enclave_wrangler.models import obj_pkey
+from enclave_wrangler.models import pkey
 
 DEBUG = False
 DB = CONFIG["db"]
@@ -128,6 +128,7 @@ def sql_query(
 
 
 def get_obj_by_id(con, table: str, pkey: str, obj_id: Union[str, int]):
+    """Get object by ID"""
     return sql_query(con, f'SELECT * FROM {table} WHERE {pkey} = (:obj_id)', {'obj_id': obj_id})
 
 def insert_from_dict(con: Connection, table: str, d: Dict, skip_if_already_exists=True):
@@ -138,9 +139,9 @@ def insert_from_dict(con: Connection, table: str, d: Dict, skip_if_already_exist
     #   but other functions that call this should probably check or have this function check
 
     if skip_if_already_exists:
-        pkey = obj_pkey(table)
-        if pkey:
-            already_in_db = get_obj_by_id(con, table, pkey, d[pkey])
+        pk = pkey(table)
+        if pk:
+            already_in_db = get_obj_by_id(con, table, pk, d[pk])
             if already_in_db:
                 return
 

--- a/db_backup.sh
+++ b/db_backup.sh
@@ -20,8 +20,10 @@ Immediately upload the backup schema to the database.
 psql -d \$psql_conn < $fname.dmp
 
 Step 3: Quality control checks
-3.1. Make sure that the dump file is around 7.6G and that it appears in the database.
-3.2. Run: `make counts-compare-schemas`. If there is a difference in row counts between 'n3c' and the new backup, this will require further analysis to determine why.
+3.1. Run: `make counts-update COMMENT`
+This helps us keep track of changes in row counts at critical moments. Example: `make counts-update Just performed a backup of n3c and uploaded new backup schema.`
+3.2. Run: `make counts-compare-schemas`
+If there is a difference in row counts between 'n3c' and the new backup, this will require further analysis to determine why.
 
 END
 

--- a/enclave_wrangler/models.py
+++ b/enclave_wrangler/models.py
@@ -175,7 +175,7 @@ def add_mappings(csv_str: str):
     FMAPS.extend(maps)
 
 
-OBJ_PKEYS = {
+PKEYS = {
     'concept': 'concept_id',
     'atlasjson': 'CONCEPT_ID',
     'OMOPConcept': 'conceptId',
@@ -185,8 +185,9 @@ OBJ_PKEYS = {
     'OMOPConceptSetContainer': 'conceptSetId',
     'concept_set_container': 'concept_set_id',
 }
-def obj_pkey(obj):
-    return OBJ_PKEYS[obj]
+def pkey(obj):
+    """Get primary key for given object or  table."""
+    return PKEYS.get(obj, None)
 
 # OMOPConcept (concept): dataset <-> atlasjson
 add_mappings(

--- a/enclave_wrangler/objects_api.py
+++ b/enclave_wrangler/objects_api.py
@@ -30,7 +30,7 @@ from enclave_wrangler.config import FAVORITE_OBJECTS, OUTDIR_OBJECTS, OUTDIR_CSE
 from enclave_wrangler.utils import enclave_get, enclave_post, get_objects_df, get_url_from_api_path, \
     make_objects_request, \
     handle_paginated_request, handle_response_error
-from enclave_wrangler.models import convert_row, get_field_names, field_name_mapping, obj_pkey
+from enclave_wrangler.models import convert_row, get_field_names, field_name_mapping, pkey
 # from enclave_wrangler.utils import log_debug_info
 from backend.db.utils import insert_from_dict, sql_query_single_col, run_sql, get_db_connection, get_obj_by_id
 from backend.db.queries import get_concepts
@@ -392,7 +392,7 @@ def fetch_cset_expression_item(object_id: int) -> Dict:
 
 def fetch_object_and_add_to_db(con: Connection, table: str, object_type_name: str, object_id: Union[int, str]) -> Dict:
     """Fetch object and add to db"""
-    already_in_db = get_obj_by_id(con, table, obj_pkey(table), object_id)
+    already_in_db = get_obj_by_id(con, table, pkey(table), object_id)
     if (already_in_db):
         print(f'{table}:{object_id} is already in db')
         return already_in_db

--- a/makefile
+++ b/makefile
@@ -2,28 +2,41 @@ SRC=backend/
 
 .PHONY: lint tags ltags test all lintall codestyle docstyle lintsrc \
 linttest doctest doc docs code linters_all codesrc codetest docsrc \
-doctest
+doctest counts-compare-schemas counts-table deltas-table
 
 # Analysis
 ANALYSIS_SCRIPT = 'backend/db/analysis.py'
 
+# Checks counts of database tables for the current 'n3c' schema and its most recent backup.
 counts-compare-schemas:
 	@python3 $(ANALYSIS_SCRIPT) --counts-compare-schemas
 
+# View counts row counts over time for the 'n3c' schema.
 counts-table:
-	@python3 $(ANALYSIS_SCRIPT) --counts-over-time print_counts_table
+	@python3 $(ANALYSIS_SCRIPT) --counts-over-time
 
+# View row count detlas over time for the 'n3c' schema.
 deltas-table:
-	@python3 $(ANALYSIS_SCRIPT) --counts-over-time print_delta_table
+	@python3 $(ANALYSIS_SCRIPT) --deltas-over-time
 
-deltas-viz:
-	@python3 $(ANALYSIS_SCRIPT) --counts-over-time save_delta_viz
-
+# todo
+#deltas-viz:
+#	@python3 $(ANALYSIS_SCRIPT) --counts-over-time save_delta_viz
 #counts-viz:
 #	@python3 $(ANALYSIS_SCRIPT) --counts-over-time save_counts_viz
 
+# counts-update
+ifeq (counts-update,$(firstword $(MAKECMDGOALS)))
+  # use the rest as arguments for "counts-updates"
+  COUNTS_UPDATE_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))
+  # ...and turn them into do-nothing targets
+  $(eval $(COUNTS_UPDATE_ARGS):;@:)
+endif
 counts-update:
-	@python3 $(ANALYSIS_SCRIPT) --counts-updte
+	@python3 $(ANALYSIS_SCRIPT) --counts-update --note "$(COUNTS_UPDATE_ARGS)"
+
+counts-help:
+	@python3 $(ANALYSIS_SCRIPT) --help
 
 # Codestyle, linters, and testing
 # - Code & Style Linters


### PR DESCRIPTION
DB Counts
- Update: pdated some comments / documentation
- Update: counts_update(): Now the first time that it runs, the delta values are equal to the row counts, rather than being set to 0.
- Add: table 'counts_runs'. It is initalized in initialize.py, and used by counts_update().
- Add: param --note: to counts_update(). Required. Adds context to why the counts were ran at that particular time, e.g. after a backup or a data fetch.
- Bugfix: Fixed situation where table was new and not included in the last counts run. This was resulting in an error when trying to cast an empty pandas.Series to int().
- Update: Docs: (i) db_backup.sh: Includes step instructing to store row counts after doing a backup and reupload of the new backup schema.
- Update: Simplified CLI options
- Bugfix: deltas and counts over time tables' numbers' were being printed as floats instead of integers.
- Update: Added 'note' field to counts-over-time and deltas-over-time table printouts.

Backend
- Bugfix: insert_from_dict(): Fixed bug where if table being inserted to did not have a primary key, or rather was not registered as having one in OBJ_PKEYS, this would cause an exception.

Enclave Wrangler
- Rename: obj_pkey() -> pkey() & OBJ_PKEYS -> PKEYS, since these are primary keys not simply for objects, but also for tables.