### PR TITLE
DB Counts update

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -14,6 +14,9 @@ Deploys to: [termhub-dev.azurewebsites.net](https://termhub-dev.azurewebsites.ne
 Is deployed via GitHub Action: [.github/workflows/backend_dev.yml](https://github.com/jhu-bids/TermHub/blob/main/.github/workflows/backend_dev.yml)
 - Can be deployed manually from GitHub: [run workflow](https://github.com/jhu-bids/TermHub/actions/workflows/backend_dev.yml)
 
+### Analysis / DB counts
+Database counts are both over time and also when comparing schemas in as a QC measure, and can be viewed [here](../docs/backend/db/analysis.md).
+
 ### Developer notes
 From [3bfa2d](https://github.com/jhu-bids/TermHub/commit/3bfa2d) commit msg
 

--- a/backend/db/analysis.py
+++ b/backend/db/analysis.py
@@ -5,62 +5,77 @@ from argparse import ArgumentParser
 from datetime import datetime
 from pathlib import Path
 from pprint import pprint
-from typing import Dict, List
+from typing import Any, Dict, List, Union
 import dateutil.parser as dp
 import pandas as pd
+from jinja2 import Template
 from pandas import Series
+
 
 THIS_DIR = os.path.dirname(__file__)
 PROJECT_ROOT = Path(THIS_DIR).parent.parent
 sys.path.insert(0, str(PROJECT_ROOT))
+from backend.db.config import DOCS_DIR
 from backend.db.initialize import SCHEMA
-from backend.db.utils import get_db_connection, insert_from_dict, list_tables, run_sql
+from backend.db.utils import get_db_connection, insert_from_dict, list_tables, run_sql, sql_in
 
 COUNTS_OVER_TIME_OPTIONS = [
-    'print_counts_table',
-    'print_delta_table',
+    'counts_table',
+    'delta_table',
     # 'save_delta_viz'
 ]
+DOCS_PATH = os.path.join(DOCS_DIR, 'backend', 'db', 'analysis.md')
+DOCS_JINJA = """# DB row counts
+## Counts over time
+{{ counts_markdown_table }}
+
+## Deltas over time
+{{ deltas_markdown_table }}"""
 
 
-# TODO: automatically compare to most recent backup. currently fixed to a specific schema
 def counts_compare_schemas(
-    compare_schema: str = 'n3c_backup_20230414', schema: str = SCHEMA, local=False, fast_approx_method=False,
-    verbose=True
-) -> List[tuple]:
+    compare_schema: str = 'most_recent_backup', schema: str = SCHEMA, local=False, verbose=True, use_cached_counts=False
+) -> pd.DataFrame:
     """Checks counts of database tables for the current schema and its most recent backup.
 
-    :param compare_schema: The schema to check against. e.g. n3c_backup_20230322
+    :param compare_schema: The schema to check against. e.g. ncurrent_counts3c_backup_20230322
+    :param use_cached_counts: If True, will use whatever is in the `counts` table, though it is less likely that counts
+    will exist for backups. Runs much faster though if using this option.
     """
-    # TODO: automatically determine latest backup name rather than param
-    # TODO: format this to return something better. Right now looks like:
-    #  [('code_sets', 'test2_n3c', 1), ('code_sets', 'test_n3c', 1), ('concept_set_container', 'test2_n3c', 1),
-    #  ('concept_set_container', 'test_n3c', 1), ('concept_set_members', 'test2_n3c', 1), ('concept_set_members',
-    #  'test_n3c', 1), ('concept_set_version_item', 'test2_n3c', 1), ('concept_set_version_item', 'test_n3c', 1)]
-    # todo: pass params (not working right now for some reason) to run_sql() instead of string interpolating, e.g.:
-    #  WHERE schemaname in (:schema_names)...
-    # TODO: get this from the db instead of hardcoding
-    query = f"""
-    WITH tbl AS  (SELECT table_schema, TABLE_NAME
-    FROM information_schema.tables
-    WHERE TABLE_NAME not like 'pg_%' AND table_schema in ('{schema}', '{compare_schema}')) 
-    SELECT table_schema, TABLE_NAME, (xpath('/row/c/text()', query_to_xml(format('select count(*) as c from %I.%I', table_schema, TABLE_NAME), FALSE, TRUE, '')))[1]::text::int AS rows_n
-    FROM tbl
-    ORDER BY rows_n DESC
-    """
-    if fast_approx_method:
-        query = f"""
-        SELECT relname,schemaname,n_live_tup
-        FROM pg_stat_user_tables
-        WHERE schemaname in ('{schema}', '{compare_schema}')ORDER BY 1, 2, 3;"""
+    # Determine most recent schema if necessary
+    if compare_schema == 'most_recent_backup':
+        # 2nd % necessary for Python escaping
+        query = """SELECT schema_name
+        FROM information_schema.schemata
+        WHERE schema_name NOT LIKE 'pg_%%'
+        AND schema_name <> 'information_schema';
+        """
+        with get_db_connection(schema='', local=local) as con:
+            backup_schemas: List[str] = [x[0] for x in run_sql(con, query) if x[0].startswith(f'{schema}_backup_')]
+        dates: List[datetime] = [dp.parse(x.split('_')[2]) for x in backup_schemas]
+        for schema_name, date in zip(backup_schemas, dates):
+            if date == max(dates):
+                compare_schema = schema_name
 
-    with get_db_connection(schema=schema, local=local) as con:
-        result = run_sql(con, query)
-        result = [x for x in result]
+    # Get counts
+    main: Dict = current_counts(schema, from_cache=use_cached_counts)
+    compare: Dict = current_counts(compare_schema, from_cache=use_cached_counts)
+    tables = set(main.keys()).union(set(compare.keys()))
+    rows = []
+    for table in tables:
+        main_count = main[table]['count'] if table in main else 0
+        compare_count = compare[table]['count'] if table in compare else 0
+        rows.append({
+            'table': table,
+            'delta': main_count - compare_count,
+            schema: main_count,
+            compare_schema: compare_count,
+        })
+    df = pd.DataFrame(rows)
 
     if verbose:
-        pprint(result)
-    return result
+        print(df)
+    return df
 
 
 def counts_update(note: str, schema: str = SCHEMA, local=False):
@@ -70,10 +85,6 @@ def counts_update(note: str, schema: str = SCHEMA, local=False):
     a data fetch from the enclave, or after editing a batch of concept sets.
     """
     dt = datetime.now()
-    # Fetch current tables
-    with get_db_connection(schema=schema, local=local) as con:
-        tables: List[str] = list_tables(con)
-    # DB updates
     with get_db_connection(schema='', local=local) as con:
         # Save run metadata, e.g. a note about it
         insert_from_dict(con, 'counts_runs', {
@@ -82,11 +93,35 @@ def counts_update(note: str, schema: str = SCHEMA, local=False):
             'schema': schema,
             'note': note,
         })
-        # Save row counts
-        timestamps: List[datetime] = [dp.parse(x[0]) for x in run_sql(con, f'SELECT DISTINCT timestamp from counts;')]
+        # Save counts
+        # noinspection PyCallingNonCallable pycharm_doesnt_undestand_its_returning_dict
+        for d in current_counts(from_cache=False).values():
+            insert_from_dict(con, 'counts', d)
+
+
+def current_counts(
+    schema: str = SCHEMA, local=False, from_cache=False, return_as=['dict', 'df'][0]
+) -> Union[pd.DataFrame, Dict]:
+    """Gets current database counts"""
+    if from_cache:
+        with get_db_connection(schema='', local=local) as con:
+            counts: List[Dict] = [dict(x) for x in run_sql(con, f'SELECT * from counts;')]
+            df = pd.DataFrame(counts)
+            df = df[df['schema'] == schema]
+            return df
+    dt = datetime.now()
+    # Get tables
+    with get_db_connection(schema=schema, local=local) as con:
+        tables: List[str] = list_tables(con)
+    with get_db_connection(schema='', local=local) as con:
+        # Get previous counts
+        timestamps: List[datetime] = [
+            dp.parse(x[0]) for x in run_sql(con, f'SELECT DISTINCT timestamp from counts;')]
         most_recent_timestamp: str = str(max(timestamps))
         prev_counts: List[Dict] = [dict(x) for x in run_sql(con, f'SELECT * from counts;')]
         prev_counts_df = pd.DataFrame(prev_counts)
+        # Get counts
+        table_rows: Dict[str, Dict[str, Any]] = {}
         for table in tables:
             count: int = [x for x in run_sql(con, f'SELECT COUNT(*) from n3c.{table};')][0][0]
             last_count_fetch: Series = prev_counts_df[
@@ -94,55 +129,91 @@ def counts_update(note: str, schema: str = SCHEMA, local=False):
                 (prev_counts_df['table'] == table)]['count']
             last_count_fetch2: List[int] = list(last_count_fetch.to_dict().values())
             last_count: int = int(last_count_fetch2[0]) if prev_counts and last_count_fetch2 else 0
-            insert_from_dict(con, 'counts', {
+            table_rows[table] = {
                 'date': dt.strftime('%Y-%m-%d'),
                 'timestamp': str(dt),
                 'schema': schema,
                 'table': table,
                 'count': count,
                 'delta': count - last_count,
-            })
+            }
+    return table_rows if return_as == 'dict' else pd.DataFrame(table_rows)
 
 
 # TODO: support multiple schema
+# TODO: the _print feature is actually truncated when printed. not useful; maybe a way to print untruncated / else CSV?
 def counts_over_time(
-    schema: str = SCHEMA, local=False, method=COUNTS_OVER_TIME_OPTIONS[0]
-):
+    schema: str = SCHEMA, local=False, method=COUNTS_OVER_TIME_OPTIONS[0], _print=True,
+    current_counts_df: pd.DataFrame = pd.DataFrame()
+) -> pd.DataFrame:
     """Checks counts of database and store what the results look like in a database over time"""
     if method not in COUNTS_OVER_TIME_OPTIONS:
         raise ValueError(f'counts_over_time(): Invalid method {method}. Must be one of {COUNTS_OVER_TIME_OPTIONS}')
+    current_counts_df = current_counts_df if len(current_counts_df) > 0 else current_counts(schema, local)
+
+    # Pivot
+    values = 'count' if method == 'counts_table' else 'delta'
+    data_df = current_counts_df.pivot(index='table', columns='timestamp', values=values).fillna(0).astype(int)
+
+    # Add note
     with get_db_connection(schema='', local=local) as con:
-        # Get counts
-        counts: List[Dict] = [dict(x) for x in run_sql(con, f'SELECT * from counts;')]
-        counts_df = pd.DataFrame(counts)
-        counts_df = counts_df[counts_df['schema'] == schema]
-        values = 'count' if method == 'print_counts_table' else 'delta'
-        data_df = counts_df.pivot(index='table', columns='timestamp', values=values).fillna(0).astype(int)
-        # Add note
-        # todo
         runs = [dict(x) for x in run_sql(con, f'SELECT timestamp, note from counts_runs;')]
-        timestamps = [x['timestamp'] for x in runs]
-        ts_dict = {}
-        for ts in timestamps:
-            for run in runs:
-                if run['timestamp'] == ts:
-                    ts_dict[ts] = run['note']
-        runs_df = pd.DataFrame([ts_dict])
-        runs_df.index = ['COMMENT']
-        df = pd.concat([runs_df, data_df])
-        # Print / save
-        if method == 'save_delta_viz':
-            raise NotImplementedError('Option save_delta_viz for counts_over_time() not yet implemented.')
-        else:
-            print(df)
+    timestamps = [x['timestamp'] for x in runs]
+    ts_dict = {}
+    for ts in timestamps:
+        for run in runs:
+            if run['timestamp'] == ts:
+                ts_dict[ts] = run['note']
+    runs_df = pd.DataFrame([ts_dict])
+    runs_df = runs_df.reindex(sorted(runs_df.columns), axis=1)
+    runs_df.index = ['COMMENT']
+    df = pd.concat([runs_df, data_df])
+
+    # Simplify column headers: timestamps -> 'DATE (N)'
+    new_cols = []
+    date_count = {}
+    for ts in df.columns:
+        # dt = datetime.strptime(ts, "%Y-%m-%d %H:%M:%S.%f")
+        # date = dt.date()
+        date = ts[:10]
+        count = date_count.get(date, 0) + 1
+        date_count[date] = count
+        new_cols.append(date + " " + str(count) if count > 1 else date)
+    df.columns = new_cols
+
+    # Print / save
+    if method == 'save_delta_viz':
+        raise NotImplementedError('Option save_delta_viz for counts_over_time() not yet implemented.')
+    elif _print:
+        print(df.to_markdown(index=False))
+    return df
+
+
+def docs(notify=True):
+    """Runs --counts-over-time and --deltas-over-time and puts in documentation: docs/backend/db/analysis.md."""
+    # Get data
+    current_counts_df = current_counts()
+    counts_df: pd.DataFrame = counts_over_time(method='counts_table', current_counts_df=current_counts_df, _print=False)
+    deltas_df: pd.DataFrame = counts_over_time(method='delta_table', current_counts_df=current_counts_df, _print=False)
+    # Write docs
+    instantiated_str: str = Template(DOCS_JINJA).render(
+        counts_markdown_table=counts_df.to_markdown(),
+        deltas_markdown_table=deltas_df.to_markdown())
+    with open(DOCS_PATH, 'w') as f:
+        f.write(instantiated_str)
+    # Notify
+    if notify:
+        pass
+        # todo: need new method; Gmail doesn't work anymore. See: send_email() docstring
+        # send_email(
+        #     subject="TermHub DB counts docs updated",
+        #     body="When/if pushed to develop branch, will appear here: "
+        #          "https://github.com/jhu-bids/TermHub/blob/develop/docs/backend/db/analysis.md")
 
 
 def cli():
     """Command line interface."""
     parser = ArgumentParser(prog='TermHub DB analysis utils.', description='Various analyses for DB.')
-    parser.add_argument(
-        '-s', '--counts-compare-schemas', action='store_true',
-        help="Checks counts of database tables for the current 'n3c' schema and its most recent backup.")
     parser.add_argument(
         '-c', '--counts-over-time', action='store_true',
         help="View counts row counts over time for the 'n3c' schema.")
@@ -150,11 +221,27 @@ def cli():
         '-d', '--deltas-over-time', action='store_true',
         help="View row count deltas over time for the 'n3c' schema.")
     parser.add_argument(
+        '-D', '--counts-docs', action='store_true',
+        help="Runs --counts-over-time and --deltas-over-time and puts in documentation: docs/backend/db/analysis.md.")
+    # --counts-update and its args
+    parser.add_argument(
         '-u', '--counts-update', action='store_true',
         help="Update 'counts' table with current row counts for the 'n3c' schema.")
     parser.add_argument(
         '-n', '--note',
         help="Only used with `--counts-update`. Add a note to the 'counts-runs' table.")
+    parser.add_argument(
+        '-S', '--schema', default=SCHEMA,
+        help="Only used with `--counts-update` and --counts-compare-schemas. Selects which schema's tables to count.")
+    # --counts-compare-schemas and its args
+    parser.add_argument(
+        '-s', '--counts-compare-schemas', action='store_true',
+        help="Checks counts of database tables for the current 'n3c' schema and its most recent backup.")
+    parser.add_argument(
+        '-C', '--schema-to-compare', default='most_recent_backup',
+        help="Only used with `--counts-compare-schemas`. Selects which schema to compare to --schema (which by default "
+             f"is '{SCHEMA}'). Default for schema to compare is whatever backup was the most recent, following naming "
+             f"pattern of 'n3c_backup_YYYYMMDD'.")
 
     d: Dict = vars(parser.parse_args())
     if d['counts_update']:
@@ -162,15 +249,17 @@ def cli():
         if not note:
             print('Error: Must provide a --note when using --counts-update.', file=sys.stderr)
         else:
-            counts_update(note)
+            counts_update(note, d['schema'])
     elif d['counts_compare_schemas']:
-        counts_compare_schemas()
+        counts_compare_schemas(d['schema_to_compare'], d['schema'])
     elif d['counts_over_time']:
-        counts_over_time(method='print_counts_table')
+        counts_over_time(method='counts_table')
     elif d['deltas_over_time']:
-        counts_over_time(method='print_delta_table')
+        counts_over_time(method='delta_table')
+    elif d['counts_docs']:
+        docs()
     else:
-        print('Error: Choose an option. Can see available options by running with --help', file=sys.stderr)
+        print('Error: Choose 1 and only 1 option. Can see available options by running with --help', file=sys.stderr)
 
 
 if __name__ == '__main__':

--- a/backend/db/config.py
+++ b/backend/db/config.py
@@ -5,6 +5,7 @@ from dotenv import load_dotenv
 DB_DIR = os.path.dirname(os.path.realpath(__file__))
 BACKEND_DIR = os.path.join(DB_DIR, '..')
 PROJECT_ROOT = os.path.join(BACKEND_DIR, '..')
+DOCS_DIR = os.path.join(PROJECT_ROOT, 'docs')
 ENV_DIR = os.path.join(PROJECT_ROOT, 'env')
 ENV_FILE = os.path.join(ENV_DIR, '.env')
 TERMHUB_CSETS_PATH = os.path.join(PROJECT_ROOT, 'termhub-csets')

--- a/backend/db/utils.py
+++ b/backend/db/utils.py
@@ -174,10 +174,6 @@ def run_sql(con: Connection, command: str, params: Dict = {}) -> Any:
     else:
         q = con.execute(command)
     return q
-    # try:
-    #     return con.execute(command)
-    # except (ProgrammingError, OperationalError):
-    #     raise RuntimeError(f'Got an error executing the following statement:\n{command}')
 
 
 def sql_query_single_col(*argv) -> List:

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -2,6 +2,8 @@
 import functools
 import json
 import operator
+import os
+import smtplib
 import traceback
 from functools import reduce
 from typing import Any, Dict, List, Union
@@ -9,6 +11,44 @@ from datetime import datetime
 from starlette.responses import JSONResponse
 
 JSON_TYPE = Union[Dict, List]
+
+def commify(n):
+    """Those dirty commies
+    ░░░░░░░░░░▀▀▀██████▄▄▄░░░░░░░░░░
+    ░░░░░░░░░░░░░░░░░▀▀▀████▄░░░░░░░
+    ░░░░░░░░░░▄███████▀░░░▀███▄░░░░░
+    ░░░░░░░░▄███████▀░░░░░░░▀███▄░░░
+    ░░░░░░▄████████░░░░░░░░░░░███▄░░
+    ░░░░░██████████▄░░░░░░░░░░░███▌░
+    ░░░░░▀█████▀░▀███▄░░░░░░░░░▐███░
+    ░░░░░░░▀█▀░░░░░▀███▄░░░░░░░▐███░
+    ░░░░░░░░░░░░░░░░░▀███▄░░░░░███▌░
+    ░░░░▄██▄░░░░░░░░░░░▀███▄░░▐███░░
+    ░░▄██████▄░░░░░░░░░░░▀███▄███░░░
+    ░█████▀▀████▄▄░░░░░░░░▄█████░░░░
+    ░████▀░░░▀▀█████▄▄▄▄█████████▄░░
+    ░░▀▀░░░░░░░░░▀▀██████▀▀░░░▀▀██░░
+    """
+    return f'{n:,}'
+
+
+def send_email(subject: str, body: str, to=['sigfried@sigfried.org', 'jflack@jhu.edu']):
+    """Send email
+    todo: Need alternative. Gmail doesn't work as of 2022/05:
+     https://support.google.com/accounts/answer/6010255
+     To help keep your account secure, from May 30, 2022,Google no longer supports the use of third-party apps or
+     devices which ask you to sign in to your Google Account using only your username and password.
+    """
+    termhub_email_user = os.getenv('TERMHUB_EMAIL_USER')
+    # create SMTP session
+    server = smtplib.SMTP('smtp.gmail.com', 587)
+    server.starttls()
+    # server = smtplib.SMTP_SSL('smtp.gmail.com', 465)
+    # login to SMTP server (not secure)
+    server.login(termhub_email_user, os.getenv('TERMHUB_EMAIL_PASS'))
+    # send email
+    server.sendmail(termhub_email_user, to, f"Subject: {subject}\n\n{body}")
+    server.quit()
 
 
 def get_timer(name:str='Timer', debug=False):
@@ -34,26 +74,6 @@ def get_timer(name:str='Timer', debug=False):
 def cnt(vals):
     """Count values"""
     return len(set(vals))
-
-
-def commify(n):
-    """Those dirty commies
-    ░░░░░░░░░░▀▀▀██████▄▄▄░░░░░░░░░░
-    ░░░░░░░░░░░░░░░░░▀▀▀████▄░░░░░░░
-    ░░░░░░░░░░▄███████▀░░░▀███▄░░░░░
-    ░░░░░░░░▄███████▀░░░░░░░▀███▄░░░
-    ░░░░░░▄████████░░░░░░░░░░░███▄░░
-    ░░░░░██████████▄░░░░░░░░░░░███▌░
-    ░░░░░▀█████▀░▀███▄░░░░░░░░░▐███░
-    ░░░░░░░▀█▀░░░░░▀███▄░░░░░░░▐███░
-    ░░░░░░░░░░░░░░░░░▀███▄░░░░░███▌░
-    ░░░░▄██▄░░░░░░░░░░░▀███▄░░▐███░░
-    ░░▄██████▄░░░░░░░░░░░▀███▄███░░░
-    ░█████▀▀████▄▄░░░░░░░░▄█████░░░░
-    ░████▀░░░▀▀█████▄▄▄▄█████████▄░░
-    ░░▀▀░░░░░░░░░▀▀██████▀▀░░░▀▀██░░
-    """
-    return f'{n:,}'
 
 
 def dump(o):

--- a/db_backup.sh
+++ b/db_backup.sh
@@ -20,9 +20,9 @@ Immediately upload the backup schema to the database.
 psql -d \$psql_conn < $fname.dmp
 
 Step 3: Quality control checks
-3.1. Run: `make counts-update COMMENT`
-This helps us keep track of changes in row counts at critical moments. Example: `make counts-update Just performed a backup of n3c and uploaded new backup schema.`
-3.2. Run: `make counts-compare-schemas`
+3.1. Run: 'make counts-update COMMENT'
+This helps us keep track of changes in row counts at critical moments. Example: 'make counts-update Just performed a backup of n3c and uploaded new backup schema.'
+3.2. Run: 'make counts-compare-schemas'
 If there is a difference in row counts between 'n3c' and the new backup, this will require further analysis to determine why.
 
 END

--- a/docs/backend/db/analysis.md
+++ b/docs/backend/db/analysis.md
@@ -1,0 +1,48 @@
+# DB row counts
+## Counts over time
+|                                           | 2023-04-27   | 2023-04-27 2                                                         | 2023-05-02    |
+|:------------------------------------------|:-------------|:---------------------------------------------------------------------|:--------------|
+| COMMENT                                   | Baseline.    | Testing new feature of adding note annotations to table counts runs. | Did a backup. |
+| all_csets                                 | 6314         | 6314                                                                 | 6314          |
+| code_sets                                 | 6314         | 6315                                                                 | 6315          |
+| concept                                   | 6902295      | 6902295                                                              | 6902295       |
+| concept_ancestor                          | 19524628     | 19524628                                                             | 19524628      |
+| concept_relationship                      | 17361726     | 17361726                                                             | 17361726      |
+| concept_relationship_plus                 | 17361726     | 17361726                                                             | 17361726      |
+| concept_set_container                     | 4188         | 4189                                                                 | 4189          |
+| concept_set_counts_clamped                | 5084         | 5084                                                                 | 5084          |
+| concept_set_json                          | 1            | 1                                                                    | 1             |
+| concept_set_members                       | 8274707      | 8274707                                                              | 8274707       |
+| concept_set_version_item                  | 1824569      | 1824569                                                              | 1824569       |
+| concepts_with_counts                      | 6902295      | 6902295                                                              | 6902295       |
+| cset_members_items                        | 8524919      | 8524919                                                              | 8524919       |
+| deidentified_term_usage_by_domain_clamped | 183386       | 183386                                                               | 183386        |
+| omopconceptset                            | 5155         | 5155                                                                 | 5155          |
+| omopconceptsetcontainer                   | 3968         | 3968                                                                 | 3968          |
+| researcher                                | 1000         | 1000                                                                 | 1000          |
+| rxnorm_med_cset                           | 34           | 34                                                                   | 34            |
+| small_snomed                              | 0            | 197214                                                               | 197214        |
+
+## Deltas over time
+|                                           | 2023-04-18   | 2023-04-27                                                           | 2023-05-02    |
+|:------------------------------------------|:-------------|:---------------------------------------------------------------------|:--------------|
+| COMMENT                                   | Baseline.    | Testing new feature of adding note annotations to table counts runs. | Did a backup. |
+| all_csets                                 | 6314         | 0                                                                    | 0             |
+| code_sets                                 | 6314         | 1                                                                    | 0             |
+| concept                                   | 6902295      | 0                                                                    | 0             |
+| concept_ancestor                          | 19524628     | 0                                                                    | 0             |
+| concept_relationship                      | 17361726     | 0                                                                    | 0             |
+| concept_relationship_plus                 | 17361726     | 0                                                                    | 0             |
+| concept_set_container                     | 4188         | 1                                                                    | 0             |
+| concept_set_counts_clamped                | 5084         | 0                                                                    | 0             |
+| concept_set_json                          | 1            | 0                                                                    | 0             |
+| concept_set_members                       | 8274707      | 0                                                                    | 0             |
+| concept_set_version_item                  | 1824569      | 0                                                                    | 0             |
+| concepts_with_counts                      | 6902295      | 0                                                                    | 0             |
+| cset_members_items                        | 8524919      | 0                                                                    | 0             |
+| deidentified_term_usage_by_domain_clamped | 183386       | 0                                                                    | 0             |
+| omopconceptset                            | 5155         | 0                                                                    | 0             |
+| omopconceptsetcontainer                   | 3968         | 0                                                                    | 0             |
+| researcher                                | 1000         | 0                                                                    | 0             |
+| rxnorm_med_cset                           | 34           | 0                                                                    | 0             |
+| small_snomed                              | 0            | 197214                                                               | 0             |

--- a/makefile
+++ b/makefile
@@ -7,17 +7,21 @@ doctest counts-compare-schemas counts-table deltas-table
 # Analysis
 ANALYSIS_SCRIPT = 'backend/db/analysis.py'
 
-# Checks counts of database tables for the current 'n3c' schema and its most recent backup.
+# counts-compare-schemas: Checks counts of database tables for the current 'n3c' schema and its most recent backup.
 counts-compare-schemas:
 	@python3 $(ANALYSIS_SCRIPT) --counts-compare-schemas
 
-# View counts row counts over time for the 'n3c' schema.
+# counts-table: View counts row counts over time for the 'n3c' schema.
 counts-table:
 	@python3 $(ANALYSIS_SCRIPT) --counts-over-time
 
-# View row count detlas over time for the 'n3c' schema.
+# deltas-table: View row count detlas over time for the 'n3c' schema.
 deltas-table:
 	@python3 $(ANALYSIS_SCRIPT) --deltas-over-time
+
+# counts-docs: Runs --counts-over-time and --deltas-over-time and puts in documentation: docs/backend/db/analysis.md.
+counts-docs:
+	@python3 $(ANALYSIS_SCRIPT) --counts-docs
 
 # todo
 #deltas-viz:
@@ -25,7 +29,7 @@ deltas-table:
 #counts-viz:
 #	@python3 $(ANALYSIS_SCRIPT) --counts-over-time save_counts_viz
 
-# counts-update
+# counts-update: Update 'counts' table with current row counts for the 'n3c' schema. Adds note to the 'counts-runs' table.
 ifeq (counts-update,$(firstword $(MAKECMDGOALS)))
   # use the rest as arguments for "counts-updates"
   COUNTS_UPDATE_ARGS := $(wordlist 2,$(words $(MAKECMDGOALS)),$(MAKECMDGOALS))

--- a/requirements-unlocked.txt
+++ b/requirements-unlocked.txt
@@ -10,6 +10,7 @@ python-multipart
 requests
 sanitize-filename
 sqlalchemy
+tabulate
 typeguard
 uvicorn[standard]
 jq

--- a/requirements.txt
+++ b/requirements.txt
@@ -149,6 +149,7 @@ sssom==0.3.25
 sssom-schema==0.9.4
 starlette==0.19.1
 stevedore==4.0.0
+tabulate==0.9.0
 tomli==2.0.1
 tox==3.28.0
 tqdm==4.65.0


### PR DESCRIPTION
Updates
    - Add: docs/backend/db/analysis.md
    - Update: docs/backend/README.md w/ link to the new analysis / db counts markdown file
    - Add: analysis.py: --counts-docs: Now saves output to docs/backend/db/analysis.md
    - Update: makefile: With corresponding 'counts-docs' command.
    - Add: package: tabulate: to Python requirements files
    - Bugfix: Changed 'make counts-compare-schemas' back to approximate method now, pending new implementation. It was erroring out.
    - Bugfix: db_backup.sh: It was errenously trying to run 'make' commands because of backticks.
    - Update: counts/deltas tables: Simplified column headers: timestamps -> 'DATE (N)'
    - Bugfix: counts/deltas tables: Ordered columns chronologically
    - Update: Added schema param to counts_update()
    - Update: counts_compare_schema(): compare_schema param now set to 'most_recent_backup' by default, and most recent backup will be automatically found. Previously a recent backup name was hard-coded here.
    - Update: current_counts(): Now can calculate current counts without fetching from cache, which was something which was being done as an intermediate step in counts_update()
    - Update: counts_update(): Refactored the part where it gets current counts into a different function. Now it just does updates only.