### PR TITLE
Filtering 0-member code sets

### DIFF
--- a/backend/db/initialize.py
+++ b/backend/db/initialize.py
@@ -72,7 +72,7 @@ def initialize(
             create_database(con, schema)
         if download:
             download_artefacts(force_download_if_exists=download_force_if_exists)
-        seed(con, schema, clobber, hours_threshold_for_updates)
+        seed(con, schema, clobber, hours_threshold_for_updates, local=local)
         indexes_and_derived_tables(con, schema, local=local)  # , start_step=30)
         initialize_test_schema(con, schema, local=local)
 

--- a/backend/db/reset_and_update.py
+++ b/backend/db/reset_and_update.py
@@ -34,9 +34,10 @@ def reset_and_update_db(
     use_local_database=False, run_final_ddl_only=False
 ):
     """Refresh the database"""
+    local = use_local_database
     if run_final_ddl_only:
-        with get_db_connection(local=use_local_database) as con:
-            indexes_and_derived_tables(con, schema, local=use_local_database)
+        with get_db_connection(local=local) as con:
+            indexes_and_derived_tables(con, schema, local=local)
         print('INFO: Indexes and derived tables complete.')
         return
 
@@ -66,14 +67,14 @@ def reset_and_update_db(
         download_favorite_datasets(force_if_exists=not skip_download_if_exists, single_group='vocab')
 
     # Uploads
-    with get_db_connection(local=use_local_database) as con:
+    with get_db_connection(local=local) as con:
         run_sql(con, f'CREATE SCHEMA IF NOT EXISTS {schema_new_temp};')
-    load(schema_new_temp, True, hours_threshold_for_updates, use_local_database)
-    with get_db_connection(schema=schema_new_temp, local=use_local_database) as con:
+    load(schema_new_temp, True, hours_threshold_for_updates, local)
+    with get_db_connection(schema=schema_new_temp, local=local) as con:
         run_sql(con, f'ALTER SCHEMA n3c RENAME TO {schema_old_backup};')
         run_sql(con, f'ALTER SCHEMA {schema_new_temp} RENAME TO n3c;')
-        update_db_status_var(last_updated_db_key, str(current_datetime()))
-    counts_update('DB reset and update.', schema, use_local_database)
+        update_db_status_var(last_updated_db_key, str(current_datetime()), local)
+    counts_update('DB reset and update.', schema, local)
     print('INFO: Database reset complete.')
 
 

--- a/frontend/src/pages/AboutPage.js
+++ b/frontend/src/pages/AboutPage.js
@@ -127,30 +127,35 @@ function AboutPage(props) {
 
       <TextH1>Database Refresh</TextH1>
       <TextBody>Will refresh the database with the latest data from the N3C Enclave.</TextBody>
+      <TextBody><b>IMPORTANT:</b> Concept set members are currently slowly updated in the API. As a tentative solution,
+        to prevent bugs, new containers and code sets will not be imported into TermHub until those members are also
+        available for fetching. This unfortunately slows down fetching of new code sets from being otherwise
+        instantaneous to hours or days.</TextBody>
       <TextBody>Last refresh: {dataAccessor.lastRefreshed()}</TextBody>
       <TextBody>
-        <Button variant={"contained"}
-                onClick={() => {
-                  setRefreshButtonClicked(Date());
-                  handleRefresh();
-                }}>
+        <Button
+          variant={"contained"}
+          onClick={() => {
+            setRefreshButtonClicked(Date());
+            handleRefresh();
+        }}>
           Refresh database
         </Button>
       </TextBody>
 
       <TextH1>How to's</TextH1>
       <TextH2>How to: Fix the app if it's acting weird</TextH2>
-        <ul>
-          <LI>Refresh the page</LI>
+        <ol>
+          <LI>Try: Refreshing the page</LI>
           <LI>
-            <Button variant={"contained"}
-                    onClick={() => queryClient.removeQueries()}
+            Try clicking: <Button variant={"contained"}
+              onClick={() => queryClient.removeQueries()}
             >
               Empty the data cache
             </Button>
           </LI>
           <LI>Complain to <a href="mailto:sigfried@jhu.edu">Siggie</a></LI>
-        </ul>
+        </ol>
       <TextH2>How to: Load a set of concept sets</TextH2>
         <TextBody>
           Using the select list on the CSet Search page loads the concept

--- a/test/test_enclave_wrangler.py
+++ b/test/test_enclave_wrangler.py
@@ -33,7 +33,8 @@ from enclave_wrangler.dataset_upload import upload_new_cset_container_with_conce
 
 from enclave_wrangler.objects_api import concept_enclave_to_db, \
     concept_expression_enclave_to_db, concept_set_container_enclave_to_db, cset_version_enclave_to_db, \
-    csets_and_members_to_db, fetch_cset_and_member_objects, all_new_objects_to_db, get_concept_set_version_members
+    filter_cset_and_member_objects, csets_and_members_to_db, fetch_cset_and_member_objects, all_new_objects_to_db, \
+    get_concept_set_version_members
 
 TEST_INPUT_DIR = os.path.join(TEST_DIR, 'input', 'test_enclave_wrangler')
 TEST_SCHEMA = 'test_n3c'
@@ -49,6 +50,22 @@ class TestEnclaveWrangler(unittest.TestCase):
     #     """Test test_get_new_csets_and_members()"""
     #     csets_and_members: Dict[str, List] = fetch_cset_and_member_objects(since=yesterday)
     #     # todo: what kind of assert?
+
+    def test_filter_cset_and_member_objects(self):
+        """Test filter_cset_and_member_objects()"""
+        # pickle: based on 2023/05/23 run of: get_new_cset_and_member_objects(since=yesterday)
+        pickle_path = os.path.join(TEST_INPUT_DIR, 'test_csets_and_members_enclave_to_db', 'objects.pkl')
+        with open(pickle_path, 'rb') as file:
+            csets_and_members: Dict[str, List] = pickle.load(file)
+        # "Arthritis: Ankylosing spondylitis" has 2 entries
+        for cset in csets_and_members['OMOPConceptSet']:
+            if cset['properties']['conceptSetNameOMOP'] == 'Arthritis: Ankylosing spondylitis':
+                cset['member_items'] = []
+
+        result = filter_cset_and_member_objects(csets_and_members)
+        for obj_type in ['OMOPConceptSet', 'OMOPConceptSetContainer']:
+            self.assertLess(
+                len(result[obj_type]), len(csets_and_members[obj_type]), msg=f'Filtering did not work for {obj_type}')
 
     # TODO: Seems to be failing now because using test_n3c instead of n3c even though con schema=TEST_SCHEMA
     def test_csets_and_members_to_db(self):


### PR DESCRIPTION
DB refresh / initialize
- Bugfix: Several places in the refresh and initialize scripts were not properly getting/setting DB variables from local database if needed
- Bugfix: Db counts would report on tables we didn't care about or error out if they stopped existing; namely tables that end with _new or _old and are created temporarily as part of the DB refresh process, which could be going on in the background when running counts.
- Bugfix/UX: Filtering out of fetched containers and code sets with 0 members (due usually to the fact that they are new and the enclave releases concept set members more slowly than other data through its API)

Frontend
- Update: help/about page: Changed 'how to fix' section from unordered to ordered list