### PR TITLE
PR: Solving json download error #415

### DIFF
--- a/enclave_wrangler/actions_api.py
+++ b/enclave_wrangler/actions_api.py
@@ -579,7 +579,7 @@ def delete_concept_set_version(version_id: int, validate_first=VALIDATE_FIRST) -
 
     """
     api_name = 'delete-omop-concept-set-version'
-    expression_items: List[UUID] = get_concept_set_version_expression_items(version_id)
+    expression_items: List[UUID] = get_concept_set_version_expression_items(version_id, return_detail='id')
     # todo?: Expression items not reliably showing up after version just created: I don't know if this will be reliable
     #  100% of the time. at first... i was getting no expression items back after just creating it and trying to delete.
     #  i checked the enclave, and I saw that the version did indeed have expression items. I take this to mean that
@@ -588,7 +588,7 @@ def delete_concept_set_version(version_id: int, validate_first=VALIDATE_FIRST) -
     if not expression_items:
         print('INFO: Could not find expression items while trying to delete concept set. '
               'This probably means it was just uploaded. Trying again.')
-        expression_items: List[UUID] = get_concept_set_version_expression_items(version_id,return_detail='id')
+        expression_items: List[UUID] = get_concept_set_version_expression_items(version_id, return_detail='id')
     # Note: Ignore 'description' below. See 'cavaet 1' in this function's docstring.
     d = {
         # "apiName": api_name,

--- a/enclave_wrangler/actions_api.py
+++ b/enclave_wrangler/actions_api.py
@@ -588,7 +588,7 @@ def delete_concept_set_version(version_id: int, validate_first=VALIDATE_FIRST) -
     if not expression_items:
         print('INFO: Could not find expression items while trying to delete concept set. '
               'This probably means it was just uploaded. Trying again.')
-        expression_items: List[UUID] = get_concept_set_version_expression_items(version_id)
+        expression_items: List[UUID] = get_concept_set_version_expression_items(version_id,return_detail='id')
     # Note: Ignore 'description' below. See 'cavaet 1' in this function's docstring.
     d = {
         # "apiName": api_name,

--- a/enclave_wrangler/objects_api.py
+++ b/enclave_wrangler/objects_api.py
@@ -789,9 +789,10 @@ def refresh_tables_for_object():
 
 
 def get_concept_set_version_expression_items(
-    version_id: Union[str, int], return_detail=['id','full'][1], handle_paginated=False
+    version_id: Union[str, int], return_detail, handle_paginated=False
 ) -> List[Dict]:
-    """Get concept set version expression items"""
+    """Get concept set version expression items
+        return_detail required. can be 'id' or 'full' """
     version_id = str(version_id)
     items: List[Dict] = get_object_links(
         object_type='OMOPConceptSet',

--- a/enclave_wrangler/objects_api.py
+++ b/enclave_wrangler/objects_api.py
@@ -656,7 +656,7 @@ def get_codeset_json(codeset_id, con=get_db_connection(), use_cache=True, set_ca
     container = make_objects_request(
         f'OMOPConceptSetContainer/{quote(cset["conceptSetNameOMOP"], safe="")}',
         return_type='data', expect_single_item=True)
-    items = get_concept_set_version_expression_items(codeset_id, handle_paginated=True)
+    items = get_concept_set_version_expression_items(codeset_id, handle_paginated=True, return_detail='full')
     items_jsn = items_to_atlas_json_format(items)
 
     junk = """ What an item should look like for ATLAS JSON import format:

--- a/enclave_wrangler/objects_api.py
+++ b/enclave_wrangler/objects_api.py
@@ -789,7 +789,7 @@ def refresh_tables_for_object():
 
 
 def get_concept_set_version_expression_items(
-    version_id: Union[str, int], return_detail='full', handle_paginated=False
+    version_id: Union[str, int], return_detail=['id','full'][1], handle_paginated=False
 ) -> List[Dict]:
     """Get concept set version expression items"""
     version_id = str(version_id)

--- a/enclave_wrangler/objects_api.py
+++ b/enclave_wrangler/objects_api.py
@@ -608,9 +608,9 @@ def items_to_atlas_json_format(items):
     """Convert version items to atlas json format"""
     flags = ['includeDescendants', 'includeMapped', 'isExcluded']
     try:
-        concept_ids = [i['conceptId'] for i in items]
+        concept_ids = [i['properties']['conceptId'] for i in items]
     except Exception as err:
-        concept_ids = [i['concept_id'] for i in items]
+        concept_ids = [i['properties']['conceptId'] for i in items]
 
     # getting individual concepts from objects api is way too slow
     concepts = get_concepts(concept_ids, table='concept')
@@ -620,8 +620,8 @@ def items_to_atlas_json_format(items):
     for item in items:
         j = {}
         for flag in flags:
-            j[flag] = item[flag]
-        c = concepts[item['conceptId']]
+            j[flag] = item['properties'][flag]
+        c = concepts[item['properties']['conceptId']]
         jc = {}
         for field in mapped_atlasjson_fields:
             jc[field] = c[field_name_mapping('atlasjson', 'concept', field)]
@@ -652,9 +652,9 @@ def get_codeset_json(codeset_id, con=get_db_connection(), use_cache=True, set_ca
         """)
         if jsn:
             return jsn[0]
-    cset = make_objects_request(f'objects/OMOPConceptSet/{codeset_id}', return_type='data', expect_single_item=True)
+    cset = make_objects_request(f'OMOPConceptSet/{codeset_id}', return_type='data', expect_single_item=True)
     container = make_objects_request(
-        f'objects/OMOPConceptSetContainer/{quote(cset["conceptSetNameOMOP"], safe="")}',
+        f'OMOPConceptSetContainer/{quote(cset["conceptSetNameOMOP"], safe="")}',
         return_type='data', expect_single_item=True)
     items = get_concept_set_version_expression_items(codeset_id, handle_paginated=True)
     items_jsn = items_to_atlas_json_format(items)
@@ -789,7 +789,7 @@ def refresh_tables_for_object():
 
 
 def get_concept_set_version_expression_items(
-    version_id: Union[str, int], return_detail=['id', 'full'][0], handle_paginated=False
+    version_id: Union[str, int], return_detail='full', handle_paginated=False
 ) -> List[Dict]:
     """Get concept set version expression items"""
     version_id = str(version_id)

--- a/enclave_wrangler/utils.py
+++ b/enclave_wrangler/utils.py
@@ -193,7 +193,7 @@ def enclave_get(url: str, verbose: bool = True, args: Dict = {}, error_dir: str 
         print_curl(url, args=args)
     headers = get_headers()
     response = requests.get(url, headers=headers, **args)
-    handle_response_error(response, error_dir)
+    #handle_response_error(response, error_dir)
     return response
 
 

--- a/enclave_wrangler/utils.py
+++ b/enclave_wrangler/utils.py
@@ -161,8 +161,14 @@ def handle_response_error(
     failed = response_failed(response)
     if failed:
         print(f'Error: {calling_func}: {str(response.status_code)} {response.reason}', file=sys.stderr)
-        error_report: Dict = {'request': response.url, 'response': response.json()}
-        print(error_report, file=sys.stderr)
+        if response.headers.get('content-type'):
+            """This if statement is to check if there is JSON content in response, this is because
+            some error codes (such as 404) do not return JSON content meaning response.json() cannot be used."""
+            error_report: Dict = {'request': response.url, 'response': response.json()}
+            print(error_report, file=sys.stderr)
+        #else:
+            #I'm not sure if an error_report alternative is desired for non JSON responses'
+
         curl_str = f'curl -H "Content-type: application/json" ' \
                    f'-H "Authorization: Bearer ${get_auth_token_key()}" {response.url}'
         print(curl_str, file=sys.stderr)


### PR DESCRIPTION
The first commit removes the issues with response.json(). The exception handling still needs some work because even though the response.json() line is no longer causing problems, the code below it in 183 of enclave_wrangler/utils.py is still preventing the 404 error from being handled politely.

```python
raise EnclaveWranglerErr({
            "status_code": response.status_code,
            "text": response.text,
            # ... ?
        })
```
@Sigfried I would appreciate some clarification on the purpose of the code above. Since I don't quite understand it's purpose I'm unsure how to change it to accommodate errors without JSON content. 

As a status update @joeflack4: With Siggie's help I was able to find that the reason the json download is not working is that we are calling an enclave page that does not exist. I am still trying to figure out how to correct that.