### PR TITLE
Popup positioning

### DIFF
--- a/frontend/src/components/FlexibleContainer.js
+++ b/frontend/src/components/FlexibleContainer.js
@@ -5,7 +5,7 @@ import Draggable from "react-draggable";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 
-export function FlexibleContainer({ title, position, children }) {
+export function FlexibleContainer({ title, position, children, onOpen }) {
   const [display, setDisplay] = useState("hidden");
   const draggableRef = useRef(null);
 
@@ -20,7 +20,10 @@ export function FlexibleContainer({ title, position, children }) {
         sx={{ ...style, marginRight: "4px" }}
         variant="contained"
         color="primary"
-        onClick={() => setDisplay("show")}
+        onClick={() => {
+          setDisplay("show");
+          onOpen(0, 100);
+        }}
       >
         Show {title}
       </Button>

--- a/frontend/src/components/FlexibleContainer.js
+++ b/frontend/src/components/FlexibleContainer.js
@@ -5,7 +5,7 @@ import Draggable from "react-draggable";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 
-export function FlexibleContainer({ title, position, children, onOpen }) {
+export function FlexibleContainer({ title, position, children, boxRef }) {
   const [display, setDisplay] = useState("hidden");
   const draggableRef = useRef(null);
 
@@ -21,8 +21,12 @@ export function FlexibleContainer({ title, position, children, onOpen }) {
         variant="contained"
         color="primary"
         onClick={() => {
+          if (boxRef.open) {
+            boxRef.open++;
+          } else {
+            boxRef.open = 1;
+          }
           setDisplay("show");
-          onOpen(0, 100);
         }}
       >
         Show {title}
@@ -30,7 +34,10 @@ export function FlexibleContainer({ title, position, children, onOpen }) {
     );
     return displayedContent; // maybe better if the buttons aren't draggable
   } else if (display === "show") {
-    const closeFunc = () => setDisplay("hidden");
+    const closeFunc = () => {
+      boxRef.open--;
+      setDisplay("hidden");
+    };
     style = {
       ...style,
       zIndex: 10,
@@ -52,7 +59,10 @@ export function FlexibleContainer({ title, position, children, onOpen }) {
   return (
     <Draggable
         nodeRef={draggableRef}
-        defaultPosition={position}
+        defaultPosition={{
+          x: position.x + (boxRef.open - 1) * 50,
+          y: position.y + (boxRef.open - 1) * 50
+        }}
     >
       <Box
         ref={draggableRef}

--- a/frontend/src/components/FlexibleContainer.js
+++ b/frontend/src/components/FlexibleContainer.js
@@ -5,7 +5,7 @@ import Draggable from "react-draggable";
 import Box from "@mui/material/Box";
 import Button from "@mui/material/Button";
 
-export function FlexibleContainer({ title, position, children, boxRef }) {
+export function FlexibleContainer({ title, position, children, countRef }) {
   const [display, setDisplay] = useState("hidden");
   const draggableRef = useRef(null);
 
@@ -21,11 +21,7 @@ export function FlexibleContainer({ title, position, children, boxRef }) {
         variant="contained"
         color="primary"
         onClick={() => {
-          if (boxRef.open) {
-            boxRef.open++;
-          } else {
-            boxRef.open = 1;
-          }
+          countRef.current++;
           setDisplay("show");
         }}
       >
@@ -35,7 +31,7 @@ export function FlexibleContainer({ title, position, children, boxRef }) {
     return displayedContent; // maybe better if the buttons aren't draggable
   } else if (display === "show") {
     const closeFunc = () => {
-      boxRef.open--;
+      countRef.current--;
       setDisplay("hidden");
     };
     style = {
@@ -60,8 +56,8 @@ export function FlexibleContainer({ title, position, children, boxRef }) {
     <Draggable
         nodeRef={draggableRef}
         defaultPosition={{
-          x: position.x + (boxRef.open - 1) * 50,
-          y: position.y + (boxRef.open - 1) * 50
+          x: position.x + (countRef.current - 1) * 50,
+          y: position.y + (countRef.current - 1) * 50
         }}
     >
       <Box

--- a/frontend/src/pages/CsetComparisonPage.js
+++ b/frontend/src/pages/CsetComparisonPage.js
@@ -55,6 +55,7 @@ function CsetComparisonPage(props) {
   const {collapsePaths, collapsedDescendantPaths, nested, hideRxNormExtension, hideZeroCounts} = hierarchySettings;
   const windowSize = useWindowSize();
   const boxRef = useRef();
+  const countRef = useRef(0);
   const [panelPosition, setPanelPosition] = useState({ x: 0, y: 0 });
   const sizes = getSizes(/*squishTo*/ 1);
   const customStyles = styles(sizes);
@@ -196,7 +197,7 @@ function CsetComparisonPage(props) {
       CSV <Download></Download>
     </Button>,
     <FlexibleContainer key="legend" title="Legend"
-                       position={panelPosition} boxRef={boxRef}>
+                       position={panelPosition} countRef={countRef}>
       <Legend />
     </FlexibleContainer>,
     <Button key="add-cset"
@@ -216,7 +217,7 @@ function CsetComparisonPage(props) {
     edited_cset = selected_csets.find(cset => cset.codeset_id === editCodesetId);
     infoPanels.push(
         <FlexibleContainer key="cset" title="Concept set being edited"
-                           position={panelPosition} boxRef={boxRef}>
+                           position={panelPosition} countRef={countRef}>
           <ConceptSetCard
               cset={columns.find((d) => d.codeset_id === editCodesetId).cset_col}
               // researchers={researchers}
@@ -234,14 +235,14 @@ function CsetComparisonPage(props) {
       infoPanels.push(
           <FlexibleContainer key="changes"
                              title={`${Object.keys(csidState).length} Staged changes`}
-                             position={panelPosition} boxRef={boxRef}
+                             position={panelPosition} countRef={countRef}
           >
             <EditInfo {...props} selected_csets={selected_csets} conceptLookup={conceptLookup} />
           </FlexibleContainer>,
 
           <FlexibleContainer key="instructions"
                              title="Instructions to save changes"
-                             position={panelPosition} boxRef={boxRef}>
+                             position={panelPosition} countRef={countRef}>
             {saveChangesInstructions({ editCodesetId,
                                        csetEditState,
                                        selected_csets, })}

--- a/frontend/src/pages/CsetComparisonPage.js
+++ b/frontend/src/pages/CsetComparisonPage.js
@@ -64,6 +64,7 @@ function CsetComparisonPage(props) {
 
   useEffect(() => {
     if (boxRef.current) {
+
       let margin_text = window
           .getComputedStyle(boxRef.current)
           .getPropertyValue("margin-bottom");
@@ -155,13 +156,6 @@ function CsetComparisonPage(props) {
     hsDispatch,
   });
 
-  const popupOnOpen = (w, h) => {
-    setPanelPosition(p => ({
-      x: p.x + w,
-      y: p.y + h,
-    }));
-  };
-
   let infoPanels = [
     <Button key="distinct"
             disabled={!nested}
@@ -202,7 +196,7 @@ function CsetComparisonPage(props) {
       CSV <Download></Download>
     </Button>,
     <FlexibleContainer key="legend" title="Legend"
-                       position={panelPosition} onOpen={popupOnOpen}>
+                       position={panelPosition} boxRef={boxRef}>
       <Legend />
     </FlexibleContainer>,
     <Button key="add-cset"
@@ -221,7 +215,8 @@ function CsetComparisonPage(props) {
   if (editCodesetId) {
     edited_cset = selected_csets.find(cset => cset.codeset_id === editCodesetId);
     infoPanels.push(
-        <FlexibleContainer key="cset" title="Concept set being edited" position={panelPosition}>
+        <FlexibleContainer key="cset" title="Concept set being edited"
+                           position={panelPosition} boxRef={boxRef}>
           <ConceptSetCard
               cset={columns.find((d) => d.codeset_id === editCodesetId).cset_col}
               // researchers={researchers}
@@ -239,14 +234,14 @@ function CsetComparisonPage(props) {
       infoPanels.push(
           <FlexibleContainer key="changes"
                              title={`${Object.keys(csidState).length} Staged changes`}
-                             position={panelPosition}
+                             position={panelPosition} boxRef={boxRef}
           >
             <EditInfo {...props} selected_csets={selected_csets} conceptLookup={conceptLookup} />
           </FlexibleContainer>,
 
           <FlexibleContainer key="instructions"
                              title="Instructions to save changes"
-                             position={panelPosition}>
+                             position={panelPosition} boxRef={boxRef}>
             {saveChangesInstructions({ editCodesetId,
                                        csetEditState,
                                        selected_csets, })}

--- a/frontend/src/pages/CsetComparisonPage.js
+++ b/frontend/src/pages/CsetComparisonPage.js
@@ -75,7 +75,10 @@ function CsetComparisonPage(props) {
         y: boxRef.current.clientHeight + 2 * margin
       });
     }
-  }, []);
+  }, [
+    boxRef.current,
+    (boxRef.current ? boxRef.current.offsetHeight : 0)
+  ]);
 
   useEffect(() => {
     (async () => {

--- a/frontend/src/pages/CsetComparisonPage.js
+++ b/frontend/src/pages/CsetComparisonPage.js
@@ -77,7 +77,7 @@ function CsetComparisonPage(props) {
     }
   }, [
     boxRef.current,
-    (boxRef.current ? boxRef.current.offsetHeight : 0)
+    (boxRef.current ? boxRef.current.offsetHeight : 0),
   ]);
 
   useEffect(() => {
@@ -155,6 +155,13 @@ function CsetComparisonPage(props) {
     hsDispatch,
   });
 
+  const popupOnOpen = (w, h) => {
+    setPanelPosition(p => ({
+      x: p.x + w,
+      y: p.y + h,
+    }));
+  };
+
   let infoPanels = [
     <Button key="distinct"
             disabled={!nested}
@@ -194,7 +201,8 @@ function CsetComparisonPage(props) {
     >
       CSV <Download></Download>
     </Button>,
-    <FlexibleContainer key="legend" title="Legend" position={panelPosition}>
+    <FlexibleContainer key="legend" title="Legend"
+                       position={panelPosition} onOpen={popupOnOpen}>
       <Legend />
     </FlexibleContainer>,
     <Button key="add-cset"


### PR DESCRIPTION
Popups in the CSET COMPARISON page no longer appear at the same place every time.

When the user tries to open two popups, the second one appears a bit lower and to the right to the first one.