### PR TITLE
Bugfix: DB refresh index error

### DIFF
--- a/.github/workflows/refresh_db.yml
+++ b/.github/workflows/refresh_db.yml
@@ -3,8 +3,8 @@ name: DB Refresh (Objects API)
 on:
   schedule:
 #    - cron: '*/20 * * * *'  # every 20 minutes
-    - cron: '0 5 * * *'  # every day 5am GMT (12-1am EST/EDT)
-#    - cron: '0 * * * *'  # every hour on the hour
+#    - cron: '0 5 * * *'  # every day 5am GMT (12-1am EST/EDT)
+    - cron: '0 * * * *'  # every hour on the hour
   workflow_dispatch:
   repository_dispatch:
     types: [refresh-db]

--- a/backend/db/ddl-10-codeset_counts.jinja.sql
+++ b/backend/db/ddl-10-codeset_counts.jinja.sql
@@ -4,4 +4,4 @@ DROP TABLE IF EXISTS {{schema}}codeset_counts{{optional_suffix}};
 CREATE TABLE {{schema}}codeset_counts{{optional_suffix}} AS
 SELECT codeset_id, JSON_OBJECT_AGG(grp, cnt) AS counts FROM {{schema}}members_items_summary GROUP BY codeset_id;
 
-CREATE INDEX csc1 on {{schema}}codeset_counts{{optional_suffix}}(codeset_id);
+CREATE INDEX csc1{{optional_index_suffix}} ON {{schema}}codeset_counts{{optional_suffix}}(codeset_id);

--- a/backend/db/ddl-11-all_csets.jinja.sql
+++ b/backend/db/ddl-11-all_csets.jinja.sql
@@ -55,6 +55,6 @@ SELECT ac.*, cscnt.counts, cscnt.counts->>'Members' as concepts
 FROM ac
 LEFT JOIN {{schema}}codeset_counts cscnt ON ac.codeset_id = cscnt.codeset_id;
 
-CREATE INDEX ac_idx1 ON {{schema}}all_csets{{optional_suffix}}(codeset_id);
+CREATE INDEX ac_idx1{{optional_index_suffix}} ON {{schema}}all_csets{{optional_suffix}}(codeset_id);
 
-CREATE INDEX ac_idx2 ON {{schema}}all_csets{{optional_suffix}}(concept_set_name);
+CREATE INDEX ac_idx2{{optional_index_suffix}} ON {{schema}}all_csets{{optional_suffix}}(concept_set_name);

--- a/backend/db/ddl-12-csets_to_ignore.jinja.sql
+++ b/backend/db/ddl-12-csets_to_ignore.jinja.sql
@@ -1,5 +1,4 @@
 -- Table: csets_to_ignore ----------------------------------------------------------------------------------------------
-
 CREATE OR REPLACE VIEW {{schema}}csets_to_ignore{{optional_suffix}} AS
 SELECT all_csets.concept_set_name,
     all_csets.container_created_at,

--- a/backend/db/ddl-13-cset_members_items_plus.jinja.sql
+++ b/backend/db/ddl-13-cset_members_items_plus.jinja.sql
@@ -8,6 +8,6 @@ SELECT    csmi.*
         , c.standard_concept
 FROM {{schema}}cset_members_items csmi
 JOIN concept c ON csmi.concept_id = c.concept_id);
--- CREATE INDEX csmip_idx1 ON {{schema}}cset_members_items_plus{{optional_suffix}}(codeset_id);
--- CREATE INDEX csmip_idx2 ON {{schema}}cset_members_items_plus{{optional_suffix}}(concept_id);
--- CREATE INDEX csmip_idx3 ON {{schema}}cset_members_items_plus{{optional_suffix}}(codeset_id, concept_id);
+-- CREATE INDEX csmip_idx1{{optional_index_suffix}} ON {{schema}}cset_members_items_plus{{optional_suffix}}(codeset_id);
+-- CREATE INDEX csmip_idx2{{optional_index_suffix}} ON {{schema}}cset_members_items_plus{{optional_suffix}}(concept_id);
+-- CREATE INDEX csmip_idx3{{optional_index_suffix}} ON {{schema}}cset_members_items_plus{{optional_suffix}}(codeset_id, concept_id);

--- a/backend/db/ddl-14-concept_relationship_plus.jinja.sql
+++ b/backend/db/ddl-14-concept_relationship_plus.jinja.sql
@@ -7,7 +7,7 @@ SELECT codeset_id, array_agg(concept_id ORDER BY concept_id) concept_ids
 FROM {{schema}}cset_members_items
 GROUP BY 1;
 
-CREATE INDEX IF NOT EXISTS cbc_idx1 ON {{schema}}concept_ids_by_codeset_id{{optional_suffix}}(codeset_id);
+CREATE INDEX IF NOT EXISTS cbc_idx1{{optional_index_suffix}} ON {{schema}}concept_ids_by_codeset_id{{optional_suffix}}(codeset_id);
 
 DROP TABLE IF EXISTS {{schema}}codeset_ids_by_concept_id{{optional_suffix}} CASCADE;
 
@@ -16,4 +16,4 @@ SELECT concept_id, array_agg(codeset_id ORDER BY codeset_id) codeset_ids
 FROM {{schema}}cset_members_items
 GROUP BY 1;
 
-CREATE INDEX IF NOT EXISTS cbc_idx2 ON {{schema}}concept_ids_by_codeset_id{{optional_suffix}}(codeset_id);
+CREATE INDEX IF NOT EXISTS cbc_idx2{{optional_index_suffix}} ON {{schema}}concept_ids_by_codeset_id{{optional_suffix}}(codeset_id);

--- a/backend/db/ddl-14-concepts_with_counts_ungrouped.jinja.sql
+++ b/backend/db/ddl-14-concepts_with_counts_ungrouped.jinja.sql
@@ -17,5 +17,5 @@ SELECT DISTINCT
 FROM {{schema}}concept c
 LEFT JOIN {{schema}}deidentified_term_usage_by_domain_clamped tu ON c.concept_id = tu.concept_id);
 
-CREATE INDEX ccu_idx1 ON {{schema}}concepts_with_counts_ungrouped(concept_id);
---CREATE INDEX ccu_idx2 ON concepts_with_counts_ungrouped(concept_id);
+CREATE INDEX ccu_idx1{{optional_index_suffix}} ON {{schema}}concepts_with_counts_ungrouped(concept_id);
+--CREATE INDEX ccu_idx2{{optional_index_suffix}} ON concepts_with_counts_ungrouped(concept_id);

--- a/backend/db/ddl-15-concepts_with_counts.jinja.sql
+++ b/backend/db/ddl-15-concepts_with_counts.jinja.sql
@@ -18,7 +18,7 @@ CREATE TABLE IF NOT EXISTS {{schema}}concepts_with_counts AS (
     GROUP BY 1,2,3,4,5,6,7,8
     ORDER BY concept_id, domain );
 
-CREATE INDEX cc_idx1 ON {{schema}}concepts_with_counts(concept_id);
+CREATE INDEX cc_idx1{{optional_index_suffix}} ON {{schema}}concepts_with_counts(concept_id);
 
 -- the following drop table is causing errors with the initialize script
 -- @joeflack4: this table isn't needed after creating concepts_with_counts

--- a/backend/db/ddl-16-concept_relationship_plus.jinja.sql
+++ b/backend/db/ddl-16-concept_relationship_plus.jinja.sql
@@ -23,16 +23,16 @@ CREATE TABLE IF NOT EXISTS {{schema}}concept_relationship_plus AS (
                 --AND c2.standard_concept IS NOT NULL
 );
 
-CREATE INDEX crp_idx1 ON {{schema}}concept_relationship_plus(concept_id_1);
+CREATE INDEX crp_idx1{{optional_index_suffix}} ON {{schema}}concept_relationship_plus(concept_id_1);
 
-CREATE INDEX crp_idx2 ON {{schema}}concept_relationship_plus(concept_id_2);
+CREATE INDEX crp_idx2{{optional_index_suffix}} ON {{schema}}concept_relationship_plus(concept_id_2);
 
-CREATE INDEX crp_idx3 ON {{schema}}concept_relationship_plus(concept_id_1, concept_id_2);
+CREATE INDEX crp_idx3{{optional_index_suffix}} ON {{schema}}concept_relationship_plus(concept_id_1, concept_id_2);
 
-CREATE INDEX crp_idx4 ON {{schema}}concept_relationship_plus(concept_code);
+CREATE INDEX crp_idx4{{optional_index_suffix}} ON {{schema}}concept_relationship_plus(concept_code);
 
-CREATE INDEX crp_idx5 ON {{schema}}concept_relationship_plus(relationship_id);
+CREATE INDEX crp_idx5{{optional_index_suffix}} ON {{schema}}concept_relationship_plus(relationship_id);
 
-CREATE INDEX crp_idx6 ON {{schema}}concept_relationship_plus(concept_name_1);
+CREATE INDEX crp_idx6{{optional_index_suffix}} ON {{schema}}concept_relationship_plus(concept_name_1);
 
-CREATE INDEX crp_idx7 ON {{schema}}concept_relationship_plus(concept_name_2);
+CREATE INDEX crp_idx7{{optional_index_suffix}} ON {{schema}}concept_relationship_plus(concept_name_2);

--- a/backend/db/ddl-4-indexes.jinja.sql
+++ b/backend/db/ddl-4-indexes.jinja.sql
@@ -1,38 +1,38 @@
 -- Indexes -------------------------------------------------------------------------------------------------------------
-CREATE INDEX concept_idx on {{schema}}concept(concept_id);
+CREATE INDEX concept_idx{{optional_index_suffix}} ON {{schema}}concept(concept_id);
 
-CREATE INDEX concept_idx2 on {{schema}}concept(concept_code);
+CREATE INDEX concept_idx2{{optional_index_suffix}} ON {{schema}}concept(concept_code);
 
-CREATE INDEX csm_idx1 on {{schema}}concept_set_members(codeset_id);
+CREATE INDEX csm_idx1{{optional_index_suffix}} ON {{schema}}concept_set_members(codeset_id);
 
-CREATE INDEX csm_idx2 on {{schema}}concept_set_members(concept_id);
+CREATE INDEX csm_idx2{{optional_index_suffix}} ON {{schema}}concept_set_members(concept_id);
 
-CREATE INDEX csm_idx3 on {{schema}}concept_set_members(codeset_id, concept_id);
+CREATE INDEX csm_idx3{{optional_index_suffix}} ON {{schema}}concept_set_members(codeset_id, concept_id);
 
-CREATE INDEX vi_idx1 on {{schema}}concept_set_version_item(codeset_id);
+CREATE INDEX vi_idx1{{optional_index_suffix}} ON {{schema}}concept_set_version_item(codeset_id);
 
-CREATE INDEX vi_idx2 on {{schema}}concept_set_version_item(concept_id);
+CREATE INDEX vi_idx2{{optional_index_suffix}} ON {{schema}}concept_set_version_item(concept_id);
 
-CREATE INDEX vi_idx3 on {{schema}}concept_set_version_item(codeset_id, concept_id);
+CREATE INDEX vi_idx3{{optional_index_suffix}} ON {{schema}}concept_set_version_item(codeset_id, concept_id);
 
-CREATE INDEX cr_idx1 on {{schema}}concept_relationship(concept_id_1);
+CREATE INDEX cr_idx1{{optional_index_suffix}} ON {{schema}}concept_relationship(concept_id_1);
 
-CREATE INDEX cr_idx2 on {{schema}}concept_relationship(concept_id_2);
+CREATE INDEX cr_idx2{{optional_index_suffix}} ON {{schema}}concept_relationship(concept_id_2);
 
-CREATE INDEX cr_idx3 on {{schema}}concept_relationship(concept_id_1, concept_id_2);
+CREATE INDEX cr_idx3{{optional_index_suffix}} ON {{schema}}concept_relationship(concept_id_1, concept_id_2);
 
-CREATE INDEX ca_idx1 on {{schema}}concept_ancestor(ancestor_concept_id);
+CREATE INDEX ca_idx1{{optional_index_suffix}} ON {{schema}}concept_ancestor(ancestor_concept_id);
 
-CREATE INDEX ca_idx2 on {{schema}}concept_ancestor(descendant_concept_id);
+CREATE INDEX ca_idx2{{optional_index_suffix}} ON {{schema}}concept_ancestor(descendant_concept_id);
 
-CREATE INDEX ca_idx3 on {{schema}}concept_ancestor(ancestor_concept_id, descendant_concept_id);
+CREATE INDEX ca_idx3{{optional_index_suffix}} ON {{schema}}concept_ancestor(ancestor_concept_id, descendant_concept_id);
 
-CREATE INDEX ca_idx4 on {{schema}}concept_ancestor(min_levels_of_separation);
+CREATE INDEX ca_idx4{{optional_index_suffix}} ON {{schema}}concept_ancestor(min_levels_of_separation);
 
-CREATE INDEX cs_idx1 on {{schema}}code_sets(codeset_id);
+CREATE INDEX cs_idx1{{optional_index_suffix}} ON {{schema}}code_sets(codeset_id);
 
-CREATE INDEX csc_idx1 on {{schema}}concept_set_container(concept_set_id);
+CREATE INDEX csc_idx1{{optional_index_suffix}} ON {{schema}}concept_set_container(concept_set_id);
 
-CREATE INDEX csc_idx2 on {{schema}}concept_set_container(concept_set_name);
+CREATE INDEX csc_idx2{{optional_index_suffix}} ON {{schema}}concept_set_container(concept_set_name);
 
-CREATE INDEX csc_idx3 on {{schema}}concept_set_container(concept_set_id, created_at DESC);
+CREATE INDEX csc_idx3{{optional_index_suffix}} ON {{schema}}concept_set_container(concept_set_id, created_at DESC);

--- a/backend/db/ddl-6-cset_members_items.jinja.sql
+++ b/backend/db/ddl-6-cset_members_items.jinja.sql
@@ -22,8 +22,8 @@ ON csm.codeset_id = item.codeset_id
 WHERE csm.codeset_id IS NOT NULL
    OR item.codeset_id IS NOT NULL;
 
-CREATE INDEX csmi_idx1 ON {{schema}}cset_members_items{{optional_suffix}}(codeset_id);
+CREATE INDEX csmi_idx1{{optional_index_suffix}} ON {{schema}}cset_members_items{{optional_suffix}}(codeset_id);
 
-CREATE INDEX csmi_idx2 ON {{schema}}cset_members_items{{optional_suffix}}(concept_id);
+CREATE INDEX csmi_idx2{{optional_index_suffix}} ON {{schema}}cset_members_items{{optional_suffix}}(concept_id);
 
-CREATE INDEX csmi_idx3 ON {{schema}}cset_members_items{{optional_suffix}}(codeset_id, concept_id);
+CREATE INDEX csmi_idx3{{optional_index_suffix}} ON {{schema}}cset_members_items{{optional_suffix}}(codeset_id, concept_id);

--- a/backend/db/ddl-7-concept_ids_by_codeset_id.jinja.sql
+++ b/backend/db/ddl-7-concept_ids_by_codeset_id.jinja.sql
@@ -6,4 +6,4 @@ SELECT codeset_id, array_agg(concept_id ORDER BY concept_id) concept_ids
 FROM {{schema}}cset_members_items
 GROUP BY 1;
 
-CREATE INDEX cbc_idx1 ON {{schema}}concept_ids_by_codeset_id{{optional_suffix}}(codeset_id);
+CREATE INDEX cbc_idx1{{optional_index_suffix}} ON {{schema}}concept_ids_by_codeset_id{{optional_suffix}}(codeset_id);

--- a/backend/db/ddl-8-codeset_ids_by_concept_id.jinja.sql
+++ b/backend/db/ddl-8-codeset_ids_by_concept_id.jinja.sql
@@ -6,4 +6,4 @@ SELECT concept_id, array_agg(codeset_id ORDER BY codeset_id) codeset_ids
 FROM {{schema}}cset_members_items
 GROUP BY 1;
 
-CREATE INDEX cbc_idx2 ON {{schema}}codeset_ids_by_concept_id{{optional_suffix}}(concept_id);
+CREATE INDEX cbc_idx2{{optional_index_suffix}} ON {{schema}}codeset_ids_by_concept_id{{optional_suffix}}(concept_id);

--- a/backend/db/ddl-9-members_items_summary.jinja.sql
+++ b/backend/db/ddl-9-members_items_summary.jinja.sql
@@ -24,4 +24,4 @@ SELECT codeset_id, 'Members' AS grp, SUM(CASE WHEN csm THEN 1 ELSE 0 END) AS cnt
 UNION
 SELECT codeset_id, 'Expression items' AS grp, SUM(CASE WHEN item THEN 1 ELSE 0 END) AS cnt FROM {{schema}}cset_members_items GROUP by 1,2;
 
-CREATE INDEX mis1 on {{schema}}members_items_summary{{optional_suffix}}(codeset_id);
+CREATE INDEX mis1{{optional_index_suffix}} ON {{schema}}members_items_summary{{optional_suffix}}(codeset_id);

--- a/backend/db/ddl_deprecated_statements.jinja.sql
+++ b/backend/db/ddl_deprecated_statements.jinja.sql
@@ -1,4 +1,4 @@
 -- Deprecated ----------------------------------------------------------------------------------------------------------
 -- CREATE TABLE IF NOT EXISTS {{schema}}concept_set_json ( codeset_id int, json json );
 
--- CREATE INDEX csj_idx ON {{schema}}concept_set_json(codeset_id);
+-- CREATE INDEX csj_idx{{optional_index_suffix}} ON {{schema}}concept_set_json(codeset_id);

--- a/backend/db/refresh.py
+++ b/backend/db/refresh.py
@@ -52,9 +52,9 @@ def refresh_db(
             # will be calling this when it's ready: all_new_objects_enclave_to_db
 
         counts_update('DB refresh.', schema, local)
+        update_db_status_var('refresh_status', 'inactive', local)
         update_db_status_var('last_refresh_success', current_datetime(), local)
         update_db_status_var('last_refresh_result', 'success', local)
-        update_db_status_var('refresh_status', 'inactive', local)
         print(f'INFO: Database refresh complete in {(datetime.now() - t0).seconds} seconds.')
 
     except Exception as err:

--- a/backend/db/utils.py
+++ b/backend/db/utils.py
@@ -5,6 +5,8 @@ todo's
 """
 import json
 import os
+from random import randint
+
 import pytz
 import dateutil.parser as dp
 from datetime import datetime, timezone
@@ -58,11 +60,11 @@ def refresh_termhub_core_cset_derived_tables(con: Connection, schema: str):
     # Create new tables and backup old ones
     print('Derived tables')
     t0 = datetime.now()
+    hash_num = '_' + str(randint(10000000, 99999999))
     for module in ddl_modules:
         print(f' - creating new table/view: {module}...')
-        statements: List[str] = get_ddl_statements(schema, [module], temp_table_suffix, 'flat')
-        main_statements = [s for s in statements if not s.startswith('CREATE INDEX')]
-        for statement in main_statements:
+        statements: List[str] = get_ddl_statements(schema, [module], temp_table_suffix, hash_num, 'flat')
+        for statement in statements:
             run_sql(con, statement)
         # todo: warn if counts in _new table not >= _old table (if it exists)?
         run_sql(con, f'ALTER TABLE IF EXISTS {schema}.{module} RENAME TO {module}_old;')
@@ -76,15 +78,7 @@ def refresh_termhub_core_cset_derived_tables(con: Connection, schema: str):
     for module in ddl_modules:
         run_sql(con, f'DROP TABLE IF EXISTS {schema}.{module}_old;')
     t1 = datetime.now()
-
-    # Indexes
-    for module in ddl_modules:
-        print(f' - creating indexes for table/view: {module}...')
-        statements: List[str] = get_ddl_statements(schema, [module], return_type='flat')
-        index_statements = [s for s in statements if s.startswith('CREATE INDEX')]
-        for statement in index_statements:
-            run_sql(con, statement)
-    print(f'Derived tables: all created in {(t1 - t0).seconds} seconds.')
+    print(f' - completed in {(t1 - t0).seconds} seconds')
 
 
 def get_db_connection(isolation_level='AUTOCOMMIT', schema: str = SCHEMA, local=False):
@@ -446,7 +440,7 @@ def list_tables(con: Connection, schema: str = SCHEMA, filter_temp_refresh_table
 
 
 def get_ddl_statements(
-    schema: str = SCHEMA, modules: List[str] = None, table_suffix='', return_type=['flat', 'nested'][1]
+    schema: str = SCHEMA, modules: List[str] = None, table_suffix='', index_suffix='', return_type=['flat', 'nested'][1]
 ) -> Union[List[str], Dict[str, List[str]]]:
     """From local SQL DDL Jinja2 templates, pa rse and get a list of SQL statements to run.
 
@@ -471,7 +465,8 @@ def get_ddl_statements(
         with open(path, 'r') as file:
             template_str = file.read()
         module = os.path.basename(path).split('-')[2].split('.')[0]
-        ddl_text = Template(template_str).render(schema=schema + '.', optional_suffix=table_suffix)
+        ddl_text = Template(template_str).render(
+            schema=schema + '.', optional_suffix=table_suffix, optional_index_suffix=index_suffix)
         without_comments = re.sub(r'^\s*--.*\n*', '', ddl_text, flags=re.MULTILINE)
         # Each DDL file should have 1 or more statements separated by an empty line (two line breaks).
         module_statements = [x + ';' for x in without_comments.split(';\n\n')]

--- a/enclave_wrangler/objects_api.py
+++ b/enclave_wrangler/objects_api.py
@@ -435,11 +435,14 @@ def filter_cset_and_member_objects(csets_and_members: Dict[str, List[Dict]]) -> 
     diff_containers = len(
         csets_and_members['OMOPConceptSetContainer']) - len(csets_and_members2['OMOPConceptSetContainer'])
     diff_csets = len(csets_and_members['OMOPConceptSet']) - len(csets_and_members2['OMOPConceptSet'])
-    print(f'  - Filtered out {diff_containers} containers and {diff_csets} code sets w/ 0 members. New total:\n    '
-          f'OBJECT_TYPE: COUNT\n' +
-          "\n".join(['    ' + str(k) + ": " + str(len(v)) for k, v in csets_and_members2.items()]))
-    print('  - Filtered containers: ' + ', '.join([x for x in filtered_containers]))
-    print('  - Filtered code sets: ' + ', '.join([x for x in filtered_csets]))
+    if diff_containers or diff_csets:
+        print(f'  - Filtered out {diff_containers} containers and {diff_csets} code sets w/ 0 members. New total:\n    '
+              f'OBJECT_TYPE: COUNT\n' +
+              "\n".join(['    ' + str(k) + ": " + str(len(v)) for k, v in csets_and_members2.items()]))
+    if filtered_containers:
+        print('  - Filtered containers: ' + ', '.join([x for x in filtered_containers]))
+    if filtered_csets:
+        print('  - Filtered code sets: ' + ', '.join([x for x in filtered_csets]))
     return csets_and_members2
 
 

--- a/enclave_wrangler/objects_api.py
+++ b/enclave_wrangler/objects_api.py
@@ -394,7 +394,7 @@ def csets_and_members_to_db(con: Connection, schema: str, csets_and_members: Dic
         objects = [obj['properties'] if 'properties' in obj else obj for obj in objects]
         add_objects_to_db(con, object_type_name, objects)
         t1 = datetime.now()
-        print(f'  - {object_type_name} inserts completed in {(t1 - t0).seconds} seconds')
+        print(f'  - completed in {(t1 - t0).seconds} seconds')
 
     # Core cset tables with: composite primary keys
     print('Running SQL inserts in core tables for: concept_set_members...')


### PR DESCRIPTION
8ecfd6c8c20fda8954aa8cff69f676882b7b3f45
DB Refresh
- Bugfix: Indexes need to be created last. Was throwing error because the index name already exists in the same schema (on the old table not yet deleted). I am unsure why this did not cause an error before. It is possible that maybe indexes were somehow not being created, but that also seems unlikely.
- Update: Reactivated DDL for csets_to_ignore

ef4289b4bd2262cca4e7822c88a9bea96e8452db
DB Refresh
- Update: Changed method of recreating indexes to increase performance.