### PR TITLE
DB Refresh: New csets with 0 members

### DIFF
--- a/.github/workflows/resolve_fetch_failures_excess_items.yml
+++ b/.github/workflows/resolve_fetch_failures_excess_items.yml
@@ -1,13 +1,13 @@
-name: Resolve fetch failures
+name: Resolve fetch failures for excess items or members
 
 on:
 #  schedule:
 #    - cron: '*/20 * * * *'  # every 20 minutes
   workflow_dispatch:
   repository_dispatch:
-    types: [resolve-fetch-failures]
+    types: [resolve-fetch-failures-excess-items]
 jobs:
-  resolve-fetch-failures:
+  resolve-fetch-failures-excess-items:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository and submodules
@@ -43,4 +43,4 @@ jobs:
 
       - name: Resolve fetch failures
         run: |
-          python backend/db/resolve_fetch_failures.py
+          python backend/db/resolve_fetch_failures_excess_items.py

--- a/backend/db/ddl-2-primary_keys.jinja.sql
+++ b/backend/db/ddl-2-primary_keys.jinja.sql
@@ -1,5 +1,5 @@
 -- Primary keys --------------------------------------------------------------------------------------------------------
--- ALTER TABLE {{schema}}concept ADD PRIMARY KEY(concept_id); -- fixing in case primary key already exists
+-- concept
 DO $$
     BEGIN
         if NOT EXISTS (SELECT constraint_name FROM {{schema}}information_schema.table_constraints WHERE table_name = 'concept' AND constraint_type = 'PRIMARY KEY') then
@@ -7,10 +7,18 @@ DO $$
         end if;
     END $$;
 
--- ALTER TABLE {{schema}}code_sets ADD PRIMARY KEY(codeset_id);
+-- code_sets
 DO $$
     BEGIN
         if NOT EXISTS (SELECT constraint_name FROM {{schema}}information_schema.table_constraints WHERE table_name = 'code_sets' AND constraint_type = 'PRIMARY KEY') then
             ALTER TABLE {{schema}}code_sets ADD PRIMARY KEY (codeset_id);
+        end if;
+    END $$;
+
+-- fetch_audit
+DO $$
+    BEGIN
+        if NOT EXISTS (SELECT constraint_name FROM information_schema.table_constraints WHERE table_name = 'fetch_audit' AND constraint_type = 'PRIMARY KEY') then
+            ALTER TABLE fetch_audit ADD PRIMARY KEY ("table", "primary_key", status_initially);
         end if;
     END $$;

--- a/backend/db/resolve_fetch_failures_0_members.py
+++ b/backend/db/resolve_fetch_failures_0_members.py
@@ -2,46 +2,125 @@
 resulting in initial fetch of concept set members being 0."""
 import os
 import sys
+import time
 from argparse import ArgumentParser
+from datetime import datetime
+from typing import Dict, List
+
 
 DB_DIR = os.path.dirname(os.path.realpath(__file__))
-BACKEND_DIR = os.path.join(DB_DIR, '..')
-PROJECT_ROOT = os.path.join(BACKEND_DIR, '..')
+BACKEND_DIR = os.path.join(DB_DIR, "..")
+PROJECT_ROOT = os.path.join(BACKEND_DIR, "..")
 sys.path.insert(0, str(PROJECT_ROOT))
-from backend.db.utils import SCHEMA, fetch_status_set_success, get_db_connection, insert_from_dicts, \
-    refresh_termhub_core_cset_derived_tables, \
-    select_failed_fetches
+from enclave_wrangler.objects_api import concept_set_members__from_csets_and_members_to_db, \
+    fetch_cset_and_member_objects
+from backend.db.utils import SCHEMA, fetch_status_set_success, get_db_connection, select_failed_fetches, \
+    refresh_termhub_core_cset_derived_tables
 
-DESC = 'Resolve any failures resulting from fetching data from the Enclave\'s objects API.'
+DESC = "Resolve any failures resulting from fetching data from the Enclave's objects API."
 
-def resolve_fetch_failures_0_members(version_id: int = None, use_local_db=False):
+
+def _report_success(
+    cset_ids: List[int], fetch_audit_row_lookup: Dict[str, Dict], comment_addition: str = None, use_local_db=False
+):
+    """Report success for a list of concept set IDs.
+    todo: kind of weird to pass a lookup. Maybe do that beforehand and pass row dict"""
+    success_rows = []
+    for cset_id in cset_ids:
+        row = fetch_audit_row_lookup[str(cset_id)]
+        if comment_addition:
+            row['comment'] = row['comment'] + '; ' + comment_addition
+        success_rows.append(row)
+    fetch_status_set_success(success_rows, use_local_db)
+
+def resolve_fetch_failures_0_members(
+    version_id: int = None, use_local_db=False, polling_interval_seconds=30, schema=SCHEMA
+):
     """Resolve situations where we tried to fetch data from the Enclave, but failed due to the concept set being too new
     resulting in initial fetch of concept set members being 0.
     :param version_id: Optional concept set version ID to resolve. If not provided, will check database for flagged
-    failures."""
-    print('Resolving fetch failures: new concept set / 0 members')
-    print('id:')
-    print(version_id)
-    if version_id:
-        print(f'Fetching version ID: {version_id}')
-        with get_db_connection(local=use_local_db) as con:
-            pass
-            # refresh_termhub_core_cset_derived_tables(con, SCHEMA)
+    failures.
+    todo: Performance: Fetch only members, ideally: Even though we are fetching 'members', adding to the cset members
+     table requires cset version and container metadata, and the function that does this expects them to be formaatted
+     as objects, not as they come from our DB. We can fetch from DB and then convert to objects, but a lot of work for
+     small performance gain."""
+    print("Resolving fetch failures: non-draft, ostensibly new concept sets with >0 expressions but 0 members")
+    # Collect failures
+    failures: List[Dict] = select_failed_fetches(use_local_db)
+    failure_lookup: Dict[str, Dict] = {x['primary_key']: x for x in failures}
+    failed_cset_ids: List[int] = [version_id] if version_id else [
+        int(x['primary_key']) for x in failures if x['status_initially'] == 'fail-0-members']
+    failed_cset_ids = list(set(failed_cset_ids))  # dedupe
+    if not failed_cset_ids:
+        print("No failures to resolve.")
+        return
+
+    # Resolve
+    i = 0
+    t0 = datetime.now()
+    print(f"Fetching concept set versions and their related objects: {', '.join([str(x) for x in failed_cset_ids])}")
+    while len(failed_cset_ids) > 0 and (datetime.now() - t0).total_seconds() < 2 * 60 * 60:  # 2 hours
+        i += 1
+        print(f"- attempt {i}: fetching members for {len(failed_cset_ids)} concept set versions")
+        # Fetch data
+        csets_and_members: Dict[str, List[Dict]] = fetch_cset_and_member_objects(
+            codeset_ids=failed_cset_ids, handle_issues=False)
+        # - filter success & track results
+        csets_and_members['OMOPConceptSet'] = [
+            x for x in csets_and_members['OMOPConceptSet'] if x['member_items']]
+        success_cases: List[int] = [
+            x['properties']['codesetId'] for x in csets_and_members['OMOPConceptSet']]
+        failed_cset_ids = list(set(failed_cset_ids) - set(success_cases))
+
+        # Update DB
+        if success_cases:
+            with get_db_connection(schema=schema, local=use_local_db) as con:
+                concept_set_members__from_csets_and_members_to_db(con, csets_and_members)
+                refresh_termhub_core_cset_derived_tables(con, SCHEMA)
+
+        # Report success
+        if success_cases:
+            print(f"Successfully fetched concept set members for concept set versions: "
+                  f"{', '.join([str(x) for x in success_cases])}")
+            _report_success(success_cases, failure_lookup, 'Success result: Found members', use_local_db)
+
+        # Sleep
+        time.sleep(polling_interval_seconds)
+
+    # Close out
+    if failed_cset_ids:
+        print(f"2 hours have passed. No members were fetched for the following concept sets, but given the length "
+              f"of time passed, members should have been available by now, and we assume that these concept sets do"
+              f" not actually have members. Reporting resolved: {', '.join([str(x) for x in failed_cset_ids])}")
+        comment = 'Success result: No members after 2 hours. Considering resolved.'
+        _report_success(failed_cset_ids, failure_lookup, comment, use_local_db)
+    else:
+        print("All failures resolved.")
 
 
-# todo: Ideally allow for output_dir for testing purposes etc, but datasets.py currently supports only 1 of 2 outdirs
-#  needed. See 'todo' above its cli() func.
 def cli():
     """Command line interface"""
-    parser = ArgumentParser(prog='Resolve fetch failures.', description=DESC)
+    parser = ArgumentParser(prog="Resolve fetch failures.", description=DESC)
     parser.add_argument(
-        '-l', '--use-local-db', action='store_true', default=False, required=False,
-        help='Use local database instead of server.')
+        "-l",
+        "--use-local-db",
+        action="store_true",
+        default=False,
+        required=False,
+        help="Use local database instead of server.")
     parser.add_argument(
-        '-v', '--version-id', required=False,
-        help='Optional concept set version ID to resolve. If not provided, will check database for flagged failures.')
+        "-v",
+        "--version-id",
+        required=False,
+        help="Optional concept set version ID to resolve. If not provided, will check database for flagged failures.")
+    parser.add_argument(
+        "-i",
+        "--polling-interval-seconds",
+        required=False,
+        default=30,
+        help="How often, in seconds, to try to fetch again if fetching still yields 0 members.")
     resolve_fetch_failures_0_members(**vars(parser.parse_args()))
 
 
-if __name__ == '__main__':
+if __name__ == "__main__":
     cli()

--- a/backend/db/resolve_fetch_failures_excess_items.py
+++ b/backend/db/resolve_fetch_failures_excess_items.py
@@ -1,4 +1,4 @@
-"""Resolve any failures resulting from fetching data from the Enclave's objects API."""
+"""Resolve failures due to too many expression items or members when fetching data from the Enclave's objects API."""
 import os
 import sys
 from argparse import ArgumentParser
@@ -16,22 +16,20 @@ from backend.db.utils import SCHEMA, fetch_status_set_success, get_db_connection
 from enclave_wrangler.datasets import CSV_TRANSFORM_DIR, download_datasets
 from enclave_wrangler.utils import was_file_modified_within_threshold
 
-DESC = 'Resolve any failures resulting from fetching data from the Enclave\'s objects API.'
+DESC = "Resolve failures due to too many expression items or members when fetching data from the Enclave's objects API."
 
-def resolve_fetch_failures(use_local_db=False, cached_dataset_threshold_hours=0):
-    """Resolve any failures resulting from fetching data from the Enclave's objects API.
-    cached_dataset_threshold_hours: default of 24 hours is good for failure cases fail-excessive*, but not for
-    fail-0-members. For that, need to set to 0.
+def resolve_fetch_failures_excess_items(use_local_db=False, cached_dataset_threshold_hours=0):
+    """Resolve failures due to too many expression items or members when fetching data from the Enclave's objects API.
+    cached_dataset_threshold_hours: Threshold, in hours, until cached datasets considered invalid and need to be
+    re-downloaded.
     """
-    print('Resolving failures for failed fetches from the Enclave\'s objects API by using datasets API instead.')
+    print('Resolve failures due to too many expression items or members when fetching data from the Enclave\'s '
+          'objects API by using datasets API instead.')
     # Vars
     datasets = ['concept_set_version_item', 'concept_set_members']
     failure_dataset_map = {
         'fail-excessive-items': 'concept_set_version_item',
         'fail-excessive-members': 'concept_set_members',
-        # 0-members: Is handled elsewhere, as not typically solvable via how resolve_fetch_failures() is used. But
-        # ...leaving it here as a failsafe.
-        'fail-0-members': 'concept_set_members',
     }
     dataset_path_map: Dict[str, str] = {ds: os.path.join(CSV_TRANSFORM_DIR, f'{ds}.csv') for ds in datasets}
 
@@ -94,7 +92,7 @@ def cli():
         '-c', '--cached-dataset-threshold-hours', required=False, default=0,
         help='Threshold, in hours, until cached datasets considered invalid and need to be re-downloaded.')
 
-    resolve_fetch_failures(**vars(parser.parse_args()))
+    resolve_fetch_failures_excess_items(**vars(parser.parse_args()))
 
 
 if __name__ == '__main__':

--- a/enclave_wrangler/models.py
+++ b/enclave_wrangler/models.py
@@ -55,14 +55,14 @@ PKEYS = {
     'concept_relationship': '',
     'relationship': '',
     'concept_ancestor': '',
-    # - Termhub: mirror tables from enclave
+    # - Mirror tables from enclave
     'concept_set_counts_clamped': '',
 
     'researcher': 'rid',  # @joeflack4, i just added pkeys here and the two lines below. hope it doesn't break anything
     'omopconceptset': 'codesetId',
     'omopconceptsetcontainer': 'conceptSetId',
     
-    # - Termhub: custom tables
+    # - Custom tables
     'all_csets': '',
     'codeset_counts': '',
     'concept_relationship_plus': '',
@@ -72,6 +72,9 @@ PKEYS = {
     'deidentified_term_usage_by_domain_clamped': '',
     'members_items_summary': '',
     'rxnorm_med_cset': '',
+
+    # - Management tables:
+    'fetch_audit': ['table', 'primary_key', 'status_initially']
 }
 
 def pkey(obj) -> str:

--- a/frontend/src/pages/AboutPage.js
+++ b/frontend/src/pages/AboutPage.js
@@ -145,10 +145,10 @@ function AboutPage() {
 
       <TextH1>Database Refresh</TextH1>
       <TextBody>Will refresh the database with the latest data from the N3C Enclave.</TextBody>
-      <TextBody><b>IMPORTANT:</b> Concept set members are currently slowly updated in the API. As a tentative solution,
-        to prevent bugs, new containers and code sets will not be imported into TermHub until those members are also
-        available for fetching. This unfortunately slows down fetching of new code sets from being otherwise
-        instantaneous to hours or days.</TextBody>
+      <TextBody><b>IMPORTANT:</b> There is a delay in the Enclave where when a concept set draft is finalized, its
+        concept set members must be expanded. This can take between 20-45 minutes to complete. At that time, the members
+        will be visible in the UI and also the API for fetching by TermHub. TermHub will detect if this issue occurs and
+        will continue to check until the members are available and import them as soon as they are.</TextBody>
       <TextBody>Last refresh: {lastRefreshed ? lastRefreshed.toLocaleString() : 'fetching it...'}</TextBody>
       <TextBody>
         <Button

--- a/test/backend_tests/db/test_utils.py
+++ b/test/backend_tests/db/test_utils.py
@@ -14,7 +14,7 @@ from sqlalchemy.engine.base import Connection
 TEST_DIR = os.path.dirname(__file__)
 PROJECT_ROOT = Path(TEST_DIR).parent.parent.parent
 sys.path.insert(0, str(PROJECT_ROOT))
-from backend.db.utils import get_db_connection, insert_fetch_status, run_sql, select_failed_fetches, sql_query
+from backend.db.utils import get_db_connection, insert_fetch_statuses, run_sql, select_failed_fetches, sql_query
 
 
 class FetchAuditTestRunner(unittest.TestCase):
@@ -27,7 +27,7 @@ class FetchAuditTestRunner(unittest.TestCase):
         """setUp"""
         cls.con = get_db_connection(schema='')
         cls.n1 = sql_query(cls.con, 'SELECT COUNT(*) FROM fetch_audit;')[0]['count']
-        insert_fetch_status(cls.mock_data)
+        insert_fetch_statuses(cls.mock_data)
 
     @classmethod
     def tearDownClass(cls):

--- a/test/backend_tests/test_resolve_fetch_failures.py
+++ b/test/backend_tests/test_resolve_fetch_failures.py
@@ -6,7 +6,7 @@ How to run:
 import os
 import sys
 from pathlib import Path
-from backend.db.resolve_fetch_failures import resolve_fetch_failures
+from backend.db.resolve_fetch_failures_excess_items import resolve_fetch_failures_excess_items
 from backend.db.utils import run_sql, sql_query
 from enclave_wrangler.objects_api import fetch_cset_and_member_objects
 from test.backend_tests.db.test_utils import FetchAuditTestRunner
@@ -47,8 +47,8 @@ class TestBackendResolveFetchFailures(FetchAuditTestRunner):
 
     # todo: A better test would be to actually run this in test_n3c, and check before/after that actual data is inserted
     #  but I don't think it'll run cuz it's still missing a few of the new tables; or maybe just 1: csets_to_ignore?
-    def test_resolve_fetch_failures(self):
-        """Test resolve_fetch_failures()"""
+    def test_resolve_fetch_failures_excess_items(self):
+        """Test resolve_fetch_failures_excess_items()"""
         pk = self.mock_data[0]['primary_key']
         query = lambda: sql_query(self.con, f"SELECT success_datetime FROM fetch_audit WHERE primary_key = '{pk}';")[-1]
         # mock_data: setUpClass will have inserted by now
@@ -56,7 +56,7 @@ class TestBackendResolveFetchFailures(FetchAuditTestRunner):
             run_sql(self.con, f"DELETE FROM fetch_audit WHERE primary_key = '{pk}' AND comment = 'Unit testing.';")
             fetch_cset_and_member_objects(codeset_ids=[pk])
         status1 = query()
-        resolve_fetch_failures()
+        resolve_fetch_failures_excess_items()
         status2 = query()
         self.assertNotEqual(status1, status2)
 


### PR DESCRIPTION
Addresses issue where we are trying to fetch a brand new concept set that has just been finalized within the last 45 minutes or so, but due to long processes that need to run in the Enclave, its concept set members were not available when we tried to fetch it, so this work will allow for a process that will continuously check until those members appear, and then we will integrate it into the DB.

Updates

    DB Refresh: New csets with 0 members
    Addresses issue where we are trying to fetch a brand new concept set that has just been finalized within the last 45 minutes or so, but due to long processes that need to run in the Enclave, its concept set members were not available when we tried to fetch it, so this work will allow for a process that will continuously check until those members appear, and then we will integrate it into the DB.
    - Add: New script for this
    - Add: New GH action
    - Update: Several functions updated to make this work
    - Update: Frontend: About page: Verbiage about the DB refresh

    DB Refresh: general
    - Update: fetch_audit table: Added primary keys
    - Bugfix: insert_fetch_status(): Was inserting duplicate rows because of a failed check if the record already existed. Because of generality of the fetch_audit table, int codeset_id needed to be converted to str before this check.
    - Add: concept_set_members__from_csets_and_members_to_db(): Useful abstraction for '0 members' wrok. Re-using in regular pipeline.
    - Rename: resolve_fetch_failures: resolve_fetch_failures_excess_items. This is to disambiguate from new script resolve_fetch_failures_0_members
    - Update: resolve_fetch_failures_excess_items: To more clearly state its purpose. Removed references of 0 members from that script.
    - Bugfix: Believe bug is fixed now where resolve_fetch_failures_excess_items() would always run during the refresh.
    - Rename: insert_fetch_status() -> insert_fetch_statuses() for clarity
    - Update: fetch failures GH action call: Now calls immediately upon failure as opposed to before when it was called once at the end of the fetch function.
    - Update: refresh_termhub_core_cset_derived_tables(): Now does not run if it is currently marked as active, and waits until inactive to start.

    General
    - Update: get_objs_by_composite_key() and get_obj_by_composite_key(): Now quotes column names, because some of our columns are keywords such as 'table' and 'primary_key'.