### PR TITLE
DB refresh: Vocab and counts tables

### DIFF
--- a/.github/workflows/refresh_voc_and_counts.yml
+++ b/.github/workflows/refresh_voc_and_counts.yml
@@ -3,7 +3,7 @@ name: Refresh vocabulary and counts tables
 on:
   schedule:
 #    - cron: '0 0 * * 0'  # weekly, sunday 12am
-#    - cron: '0 6 * * *'  # every day 6am GMT (1-2am EST/EDT)
+    - cron: '0 6 * * *'  # every day 6am GMT (1-2am EST/EDT)
   workflow_dispatch:
 jobs:
   refresh-voc-and-counts:

--- a/backend/db/config.py
+++ b/backend/db/config.py
@@ -1,5 +1,7 @@
 """Configuration for TermHub database"""
 import os
+from typing import Dict, List
+
 from dotenv import load_dotenv
 
 DB_DIR = os.path.dirname(os.path.realpath(__file__))
@@ -35,6 +37,39 @@ CONFIG_LOCAL = {
     'port': os.getenv('TERMHUB_DB_PORT_LOCAL'),
     'personal_access_token': os.getenv('GH_LIMITED_PERSONAL_ACCESS_TOKEN')
 }
+
+def invert_list_dict(d1: Dict[str, List[str]]) -> Dict[str, List[str]]:
+    """Invert a dictionary with lists as values"""
+    d2 = {}
+    for key, values in d1.items():
+        for value in values:
+            if value in d2:
+                d2[value].append(key)
+            else:
+                d2[value] = [key]
+    return d2
+
+
+def recursify_key_in_list_dict(d1: Dict[str, List[str]], key: str) -> Dict:
+    """Given a dictionary with keys and values that may or may not be keys in the dictionary, and given a specific key,
+    recursively go through and build a dictionary for that key of all of the recursive key value mappings."""
+    if key in d1:
+        inner_map = {}
+        for value in d1[key]:
+            inner_map[value] = recursify_key_in_list_dict(d1, value)
+        # return {key: inner_map}
+        return inner_map
+    else:
+        return {}
+
+
+def recursify_list_dict(d1: Dict[str, List[str]]) -> Dict[str, Dict]:
+    """Given a dictionary with keys and values that may or may not be keys in the dictionary, recursively go through and
+     build a dictionary of each key as it maps to its values."""
+    d2 = {}
+    for key in d1.keys():
+        d2[key] = recursify_key_in_list_dict(d1, key)
+    return d2
 
 def get_pg_connect_url(local=False):
     """Get URL to connect to the database server"""
@@ -75,3 +110,73 @@ BRAND_NEW_DB_URL = \
 if CONFIG["server"] == 'mysql':
     BRAND_NEW_DB_URL = BRAND_NEW_DB_URL + '?charset=utf8mb4'
 DB_URL = BRAND_NEW_DB_URL.replace(f'{CONFIG["port"]}', f'{CONFIG["port"]}/{CONFIG["db"]}')
+CORE_CSET_TABLES = ['code_sets', 'concept_set_container', 'concept_set_version_item', 'concept_set_members']
+CORE_CSET_DEPENDENT_TABLES = [
+    'cset_members_items',
+    'codeset_ids_by_concept_id',
+    'concept_ids_by_codeset_id',
+    'members_items_summary',
+    'codeset_counts',
+    'all_csets',
+    'csets_to_ignore',
+    'cset_members_items_plus',
+]
+# todo: try to auto detect what is a view
+VIEWS = [
+    'cset_members_items_plus',
+    'csets_to_ignore',
+]
+# DERIVED_TABLE_DEPENDENCY_MAP: Shows which tables are needed to create a derived table. Generally the idea is that when
+#  the dependency tables are updated, the dependent table also needs to be updated. But some tables in here have
+#  dependencies but do not meet that use case. for example, 'concept_set_members_with_dups' depends on
+#  'concept_set_members', but that table is temporary.
+# todo: are the 'module names' part of the DDL file names the same as the keys in this dictionary? If so, write that
+#  down here as a comment. Could be useful for dynamically selecting the DDL files.
+DERIVED_TABLE_DEPENDENCY_MAP = {
+    # Dependencies figured out
+    # - tables
+    'all_csets': ['code_sets', 'omopconceptset', 'concept_set_container', 'omopconceptsetcontainer', 'concept_set_counts_clamped', 'codeset_counts'],  # omopconceptset is all lowercase in DB but referred to as OMOPConceptSet in DDL and enclave object API
+    'codeset_counts': ['members_items_summary'],
+    'codeset_ids_by_concept_id': ['cset_members_items'],
+    'concept_ancestor_plus': ['concept_ancestor', 'concepts_with_counts'],
+    'concept_ids_by_codeset_id': ['cset_members_items'],
+    'concept_relationship_plus': ['concept_relationship', 'concepts_with_counts'],
+    'concepts_with_counts': ['concepts_with_counts_ungrouped'],
+    'concepts_with_counts_ungrouped': ['concept', 'deidentified_term_usage_by_domain_clamped'],
+    'cset_members_items': ['concept_set_members', 'concept_set_version_item'],
+    'members_items_summary': ['cset_members_items'],
+    # - views
+    'csets_to_ignore': ['all_csets'],
+    'cset_members_items_plus': ['cset_members_items', 'concept'],
+
+    # Unfinished / unsure
+    # - unsure what to do with these. they probably aren't derived either
+    # 'junk': [],
+    # 'omopconceptset': [],
+    # 'omopconceptsetcontainer': [],
+
+    # Non-derived tables
+    # - core cset tables
+    # 'code_sets': [],
+    # 'concept_set_version_item': [],
+    # 'concept_set_container': [],
+    # 'concept_set_members': [],
+    # # - vocab
+    # 'concept': [],
+    # 'concept_ancestor': [],
+    # 'relationship': [],
+    # 'concept_relationship': [],
+    # # - counts
+    # 'deidentified_term_usage_by_domain_clamped': [],
+    # 'concept_set_counts_clamped': [],
+    # # - objects
+    # 'researcher': [],
+
+}
+# DIRECT_DEPENDENT_TABLES: Keys are tables. Values are tables that depend on the table in the key. That is to say, when
+# the table in the key is updated, the tables in the values under that key also need to be updated. Inversion of
+#  DERIVED_TABLE_DEPENDENCY_MAP. If nothing depends on a table, it  will not appear in the keys.
+DIRECT_DEPENDENT_TABLE_MAP = invert_list_dict(DERIVED_TABLE_DEPENDENCY_MAP)
+# RECURSIVE_DEPENDENT_TABLE_MAP: Hierarchy of each table and all of the tables that depend on it. If nothing depends on
+# a table, it  will not appear in the keys.
+RECURSIVE_DEPENDENT_TABLE_MAP: Dict[str, Dict] = recursify_list_dict(DIRECT_DEPENDENT_TABLE_MAP)

--- a/backend/db/ddl-14-concepts_with_counts_ungrouped.jinja.sql
+++ b/backend/db/ddl-14-concepts_with_counts_ungrouped.jinja.sql
@@ -1,7 +1,7 @@
 -- Table view: concepts_with_counts_ungrouped --------------------------------------------------------------------------
-DROP TABLE IF EXISTS {{schema}}concepts_with_counts_ungrouped CASCADE;
+DROP TABLE IF EXISTS {{schema}}concepts_with_counts_ungrouped{{optional_suffix}} CASCADE;
 
-CREATE TABLE IF NOT EXISTS {{schema}}concepts_with_counts_ungrouped AS (
+CREATE TABLE IF NOT EXISTS {{schema}}concepts_with_counts_ungrouped{{optional_suffix}} AS (
 SELECT DISTINCT
         c.concept_id,
         c.concept_name,
@@ -17,5 +17,5 @@ SELECT DISTINCT
 FROM {{schema}}concept c
 LEFT JOIN {{schema}}deidentified_term_usage_by_domain_clamped tu ON c.concept_id = tu.concept_id);
 
-CREATE INDEX ccu_idx1{{optional_index_suffix}} ON {{schema}}concepts_with_counts_ungrouped(concept_id);
+CREATE INDEX ccu_idx1{{optional_index_suffix}} ON {{schema}}concepts_with_counts_ungrouped{{optional_suffix}}(concept_id);
 --CREATE INDEX ccu_idx2{{optional_index_suffix}} ON concepts_with_counts_ungrouped(concept_id);

--- a/backend/db/ddl-15-concepts_with_counts.jinja.sql
+++ b/backend/db/ddl-15-concepts_with_counts.jinja.sql
@@ -1,7 +1,7 @@
 -- Table: concepts_with_counts  ----------------------------------------------------------------------------------------
-DROP TABLE IF EXISTS {{schema}}concepts_with_counts CASCADE;
+DROP TABLE IF EXISTS {{schema}}concepts_with_counts{{optional_suffix}} CASCADE;
 
-CREATE TABLE IF NOT EXISTS {{schema}}concepts_with_counts AS (
+CREATE TABLE IF NOT EXISTS {{schema}}concepts_with_counts{{optional_suffix}} AS (
     SELECT  concept_id,
             concept_name,
             domain_id,
@@ -18,7 +18,7 @@ CREATE TABLE IF NOT EXISTS {{schema}}concepts_with_counts AS (
     GROUP BY 1,2,3,4,5,6,7,8
     ORDER BY concept_id, domain );
 
-CREATE INDEX cc_idx1{{optional_index_suffix}} ON {{schema}}concepts_with_counts(concept_id);
+CREATE INDEX cc_idx1{{optional_index_suffix}} ON {{schema}}concepts_with_counts{{optional_suffix}}(concept_id);
 
 -- the following drop table is causing errors with the initialize script
--- DROP TABLE {{schema}}concepts_with_counts_ungrouped CASCADE;
+-- DROP TABLE {{schema}}concepts_with_counts_ungrouped{{optional_suffix}} CASCADE;

--- a/backend/db/ddl-16-concept_relationship_plus.jinja.sql
+++ b/backend/db/ddl-16-concept_relationship_plus.jinja.sql
@@ -6,58 +6,34 @@
 -- for now, due to bug (https://github.com/jhu-bids/TermHub/issues/191 and https://github.com/jhu-bids/TermHub/pull/190)
 -- filtering out cr records including invalid concepts. this is probably not the right thing to do
 -- in the long term, but should fix bug and let us move forward with immediate need to get pilot started (2022-01-4)
-DROP TABLE IF EXISTS {{schema}}concept_relationship_plus CASCADE;
+DROP TABLE IF EXISTS {{schema}}concept_relationship_plus{{optional_suffix}} CASCADE;
 
-CREATE TABLE IF NOT EXISTS {{schema}}concept_relationship_plus AS (
+CREATE TABLE IF NOT EXISTS {{schema}}concept_relationship_plus{{optional_suffix}} AS (
   SELECT    c1.vocabulary_id AS vocabulary_id_1
           , cr.concept_id_1
           , c1.concept_name AS concept_name_1
           , c1.concept_code
-          , c1.total_cnt AS total_cnt_1,
           , cr.relationship_id
           , c2.vocabulary_id AS vocabulary_id_2
           , cr.concept_id_2
           , c2.concept_name AS concept_name_2
-          , c1.total_cnt AS total_cnt_1,
+          , c1.total_cnt AS total_cnt_1
   FROM {{schema}}concept_relationship cr
-  JOIN concepts_with_counts c1 ON cr.concept_id_1 = c1.concept_id -- AND c1.invalid_reason IS NULL
-  JOIN concepts_with_counts c2 ON cr.concept_id_2 = c2.concept_id -- AND c2.invalid_reason IS NULL
+  JOIN {{schema}}concepts_with_counts c1 ON cr.concept_id_1 = c1.concept_id -- AND c1.invalid_reason IS NULL
+  JOIN {{schema}}concepts_with_counts c2 ON cr.concept_id_2 = c2.concept_id -- AND c2.invalid_reason IS NULL
                 --AND c2.standard_concept IS NOT NULL
 );
 
-CREATE INDEX crp_idx1{{optional_index_suffix}} ON {{schema}}concept_relationship_plus(concept_id_1);
+CREATE INDEX crp_idx1{{optional_index_suffix}} ON {{schema}}concept_relationship_plus{{optional_suffix}}(concept_id_1);
 
-CREATE INDEX crp_idx2{{optional_index_suffix}} ON {{schema}}concept_relationship_plus(concept_id_2);
+CREATE INDEX crp_idx2{{optional_index_suffix}} ON {{schema}}concept_relationship_plus{{optional_suffix}}(concept_id_2);
 
-CREATE INDEX crp_idx3{{optional_index_suffix}} ON {{schema}}concept_relationship_plus(concept_id_1, concept_id_2);
+CREATE INDEX crp_idx3{{optional_index_suffix}} ON {{schema}}concept_relationship_plus{{optional_suffix}}(concept_id_1, concept_id_2);
 
-CREATE INDEX crp_idx4{{optional_index_suffix}} ON {{schema}}concept_relationship_plus(concept_code);
+CREATE INDEX crp_idx4{{optional_index_suffix}} ON {{schema}}concept_relationship_plus{{optional_suffix}}(concept_code);
 
-CREATE INDEX crp_idx5{{optional_index_suffix}} ON {{schema}}concept_relationship_plus(relationship_id);
+CREATE INDEX crp_idx5{{optional_index_suffix}} ON {{schema}}concept_relationship_plus{{optional_suffix}}(relationship_id);
 
-CREATE INDEX crp_idx6{{optional_index_suffix}} ON {{schema}}concept_relationship_plus(concept_name_1);
+CREATE INDEX crp_idx6{{optional_index_suffix}} ON {{schema}}concept_relationship_plus{{optional_suffix}}(concept_name_1);
 
-CREATE INDEX crp_idx7{{optional_index_suffix}} ON {{schema}}concept_relationship_plus(concept_name_2);
-
-DROP TABLE IF EXISTS concept_ancestor_plus CASCADE;
-
-CREATE TABLE IF NOT EXISTS concept_ancestor_plus AS (
-    SELECT
-          c1.vocabulary_id AS vocabulary_id_a
-        , ca.ancestor_concept_id
-        , c1.concept_name AS concept_name_a
-        , c1.concept_class_id AS concept_class_id_a
-        , c1.total_cnt AS total_cnt_a
-        -- , ca.min_levels_of_separation
-        , c2.vocabulary_id AS vocabulary_id_d
-        , ca.descendant_concept_id
-        , c2.concept_name AS concept_name_d
-        , c2.total_cnt AS total_cnt_d
-        , c2.concept_class_id AS concept_class_id_d
-    FROM concept_ancestor ca
-    JOIN concepts_with_counts c1 ON ca.ancestor_concept_id = c1.concept_id -- AND c1.invalid_reason IS NULL
-    JOIN concepts_with_counts c2 ON ca.descendant_concept_id = c2.concept_id -- AND c2.invalid_reason IS NULL
-);
-CREATE INDEX cap_idx1 ON concept_ancestor_plus(ancestor_concept_id);
-
-CREATE INDEX cap_idx2 ON concept_ancestor_plus(descendant_concept_id);
+CREATE INDEX crp_idx7{{optional_index_suffix}} ON {{schema}}concept_relationship_plus{{optional_suffix}}(concept_name_2);

--- a/backend/db/ddl-17-concept_ancestor_plus.jinja.sql
+++ b/backend/db/ddl-17-concept_ancestor_plus.jinja.sql
@@ -1,0 +1,23 @@
+-- Table: concept_ancestor_plus ------------------------------------------------------------------------------------
+DROP TABLE IF EXISTS {{schema}}concept_ancestor_plus{{optional_suffix}} CASCADE;
+
+CREATE TABLE IF NOT EXISTS {{schema}}concept_ancestor_plus{{optional_suffix}} AS (
+    SELECT
+          c1.vocabulary_id AS vocabulary_id_a
+        , ca.ancestor_concept_id
+        , c1.concept_name AS concept_name_a
+        , c1.concept_class_id AS concept_class_id_a
+        , c1.total_cnt AS total_cnt_a
+        -- , ca.min_levels_of_separation
+        , c2.vocabulary_id AS vocabulary_id_d
+        , ca.descendant_concept_id
+        , c2.concept_name AS concept_name_d
+        , c2.total_cnt AS total_cnt_d
+        , c2.concept_class_id AS concept_class_id_d
+    FROM {{schema}}concept_ancestor ca
+    JOIN {{schema}}concepts_with_counts c1 ON ca.ancestor_concept_id = c1.concept_id -- AND c1.invalid_reason IS NULL
+    JOIN {{schema}}concepts_with_counts c2 ON ca.descendant_concept_id = c2.concept_id -- AND c2.invalid_reason IS NULL
+);
+CREATE INDEX cap_idx1{{optional_index_suffix}} ON {{schema}}concept_ancestor_plus{{optional_suffix}}(ancestor_concept_id);
+
+CREATE INDEX cap_idx2{{optional_index_suffix}} ON {{schema}}concept_ancestor_plus{{optional_suffix}}(descendant_concept_id);

--- a/backend/db/refresh.py
+++ b/backend/db/refresh.py
@@ -64,7 +64,7 @@ def refresh_db(
         # Refresh db
         try:
             # todo: when ready, will use all_new_objects_enclave_to_db() instead of csets_and_members_enclave_to_db()
-            new_data: bool = csets_and_members_enclave_to_db(con, schema, since)
+            new_data: bool = csets_and_members_enclave_to_db(con, since, schema)
         except Exception as err:
             pass
             update_db_status_var('last_refresh_result', 'error', local)

--- a/backend/db/refresh_voc_and_counts.py
+++ b/backend/db/refresh_voc_and_counts.py
@@ -1,0 +1,78 @@
+"""Refresh vocabulary and counts tables
+
+todo's
+  1. minor: Increse performance: updates > remakeing tables
+  Similar to what DB refresh: performance: Derived tables: Inserts > remakes #448 intends w/ the derived tables, perhaps
+  we want to update tables rather than remake them? E.g. (i) deletes: when we fetch new datasets, remove any rows from
+  the corresponding DB table if they don't exist in the newly downloaded dataset (indicating that they're delated, and
+  (ii) creates: add any new rows in the new dataset if they don't exist in the corresponding table. And then there's
+  also (iii) updates: is it possible for rows/records to be updated?
+  2. Duplicative logic: runs same stuff for (i) voc, (ii) counts. can refactor to be more DRY?
+  3. CLI: add --use-local-db one day perhaps
+"""
+import os
+import sys
+from argparse import ArgumentParser
+from datetime import datetime
+
+from dateutil import parser as dp
+
+
+DB_DIR = os.path.dirname(os.path.realpath(__file__))
+BACKEND_DIR = os.path.join(DB_DIR, '..')
+PROJECT_ROOT = os.path.join(BACKEND_DIR, '..')
+sys.path.insert(0, str(PROJECT_ROOT))
+from backend.db.utils import SCHEMA, check_db_status_var, get_db_connection, load_csv, refresh_any_dependent_tables, \
+    run_sql
+from enclave_wrangler.config import DATASET_GROUPS_CONFIG
+from enclave_wrangler.datasets import download_datasets, get_last_update_of_dataset
+
+
+def refresh_voc_and_counts(skip_downloads: bool = False, schema=SCHEMA):
+    """Refresh vocabulary and counts tables."""
+    print('Refreshing vocabulary and counts tables.')
+    for group_name, config in DATASET_GROUPS_CONFIG.items():
+        if group_name == 'vocab':
+            continue
+        print(f'\nRefreshing {group_name} tables...')
+        # Check if tables are already up to date
+        last_updated_us: str = check_db_status_var(config['last_updated_termhub_var'])
+        last_updated_them: str = get_last_update_of_dataset(config['last_updated_enclave_representative_table'])
+        if last_updated_us and last_updated_them and dp.parse(last_updated_us) > dp.parse(last_updated_them):
+            print('Tables already up to date. Nothing to be done.')
+            continue
+        # Download datasets
+        if not skip_downloads:
+            print('Downloading datasets')
+            download_datasets(single_group=group_name)
+        # Load data
+        print('Loading downloaded datasets into DB tables')
+        with get_db_connection(schema=schema) as con:
+            for table in config['tables']:
+                print(f' - loading {table}...')
+                t0 = datetime.now()
+                load_csv(con, table, replace_rule='do not replace', schema=SCHEMA, optional_suffix='_new')
+                run_sql(con, f'ALTER TABLE IF EXISTS {schema}.{table} RENAME TO {table}_old;')
+                run_sql(con, f'ALTER TABLE {schema}.{table}_new RENAME TO {table};')
+                run_sql(con, f'DROP TABLE IF EXISTS {schema}.{table}_old;')
+                t1 = datetime.now()
+                print(f'   done in {(t1 - t0).seconds} seconds')
+            # todo: set variable for 'last updated' for each table (look at load())
+            #  - consider: check if table already updated sooner than last_updated_them. if so, skip. and add a param to CLI for this
+            # print('Recreating derived tables')  # printed w/in refresh_derived_tables()
+            refresh_any_dependent_tables(con, config['tables'])
+
+    print('Done')
+
+
+def cli():
+    """Command line interface"""
+    parser = ArgumentParser(prog='Refresh vocabulary and counts tables.')
+    parser.add_argument(
+        '-s', '--skip-downloads', action='store_true',
+        help='Use if you have already downloaded updated files.')
+    refresh_voc_and_counts(**vars(parser.parse_args()))
+
+
+if __name__ == '__main__':
+    cli()

--- a/backend/db/resolve_fetch_failures_0_members.py
+++ b/backend/db/resolve_fetch_failures_0_members.py
@@ -1,5 +1,7 @@
 """Resolve situations where we tried to fetch data from the Enclave, but failed due to the concept set being too new,
-resulting in initial fetch of concept set members being 0."""
+resulting in initial fetch of concept set members being 0.
+
+TODO: if every expression is set to `isExcluded=true`, we expect no members. Can add as a check rather than wait 2hrs"""
 import os
 import sys
 import time
@@ -76,7 +78,7 @@ def resolve_fetch_failures_0_members(
         if success_cases:
             with get_db_connection(schema=schema, local=use_local_db) as con:
                 concept_set_members__from_csets_and_members_to_db(con, csets_and_members)
-                refresh_termhub_core_cset_derived_tables(con, SCHEMA)
+                refresh_termhub_core_cset_derived_tables(con)
 
         # Report success
         if success_cases:

--- a/backend/db/resolve_fetch_failures_excess_items.py
+++ b/backend/db/resolve_fetch_failures_excess_items.py
@@ -74,7 +74,7 @@ def resolve_fetch_failures_excess_items(use_local_db=False, cached_dataset_thres
                 if rows:
                     insert_from_dicts(con, dataset, rows)
                     solved_failures.append(failure)
-        refresh_termhub_core_cset_derived_tables(con, SCHEMA)
+        refresh_termhub_core_cset_derived_tables(con)
 
     # Update fetch_audit status
     fetch_status_set_success(solved_failures)

--- a/docs/developer.md
+++ b/docs/developer.md
@@ -35,9 +35,8 @@ This needs to be added to `backend/db/`. The standard file naming is `ddl-N-MODU
 in which it should run relative to other such files, and `MODULE` is the module name, e.g. the name of the table(s) or
 other operations done by the DDL. When choosing the position of the file (`N`), you should put it after any / all other
 DDL which is used to create any of the tables/views that it is derived from.
-2. Update `refresh_termhub_core_cset_derived_tables()` in `backend/db/utils.py`
-There's a list variable called `ddl_modules`. Add any new `MODULE`s here. If any of those modules are views, add to the
-list variable called `views`.
+2. Update `backend/db/config.py:DERIVED_TABLE_DEPENDENCY_MAP`.
+3. Update `backend/db/config.py:DERIVED_TABLE_DEPENDENCY_MAP` if it is a view.
 
 #### Troubleshooting specific issues
 ##### `ERROR: cannot execute <COMMAND> in a read-only transaction`

--- a/enclave_wrangler/config.py
+++ b/enclave_wrangler/config.py
@@ -56,7 +56,7 @@ if missing_env_vars:
         f'{", ".join(missing_env_vars)}\n'
         f'{cause_msg}')
 
-FAVORITE_OBJECTS = [
+OBJECT_REGISTRY = [
     'researcher',
     # 'research-project',
 
@@ -77,7 +77,7 @@ FAVORITE_OBJECTS = [
 # todo: All indexes should be listed here, and initialize/refresh refactored such that indexex get created by generating
 #  SQL from here, rather than reading from the DDL files.
 # Ordered because of transformation dependencies
-FAVORITE_DATASETS = OrderedDict({
+DATASET_REGISTRY = OrderedDict({
     # apparently concept_set_container has a lot more rows than concept_set_container_edited. not sure
     #   why we were getting edited or why they're different
     'concept_set_container': {
@@ -145,14 +145,14 @@ FAVORITE_DATASETS = OrderedDict({
         'rid': 'ri.foundry.main.dataset.f945409a-37f1-402f-a840-29b6bd675cb0',
         'column_names': ["codeset_id", "approx_distinct_person_count", "approx_total_record_count"],
         'sort_idx': ['codeset_id'],
-        'dataset_groups': ['vocab']
+        'dataset_groups': ['counts']
     },
     'deidentified_term_usage_by_domain_clamped': { # gets downloaded as csv without column names, not parquet
         'name': 'deidentified_term_usage_by_domain_clamped',
         'rid': 'ri.foundry.main.dataset.e393f03a-00d0-4071-802c-ff20e543ce01',
         'column_names': ["concept_id", "domain", "total_count", "distinct_person_count"],
         'sort_idx': ['concept_id', 'domain'],
-        'dataset_groups': ['vocab']
+        'dataset_groups': ['counts']
     },
     'relationship': { # gets downloaded as csv without column names, not parquet
         'name': 'relationship',
@@ -173,7 +173,21 @@ FAVORITE_DATASETS = OrderedDict({
     #     'rid': '',
     # },
 })
-FAVORITE_DATASETS_RID_NAME_MAP = {
+DATASET_REGISTRY_RID_NAME_MAP = {
     v['rid']: k
-    for k, v in FAVORITE_DATASETS.items()
+    for k, v in DATASET_REGISTRY.items()
+}
+DATASET_GROUPS_CONFIG = {
+    'vocab': {
+        'last_updated_termhub_var': 'last_refreshed_vocab_tables',
+        'last_updated_enclave_representative_table': 'concept',
+        'dataset_group': 'vocab',
+        'tables': [x['name'] for x in DATASET_REGISTRY.values() if 'vocab' in x['dataset_groups']]
+    },
+    'counts': {
+        'last_updated_termhub_var': 'last_refreshed_counts_tables',
+        'last_updated_enclave_representative_table': 'concept_set_counts_clamped',
+        'dataset_group': 'counts',
+        'tables': [x['name'] for x in DATASET_REGISTRY.values() if 'counts' in x['dataset_groups']]
+    }
 }

--- a/enclave_wrangler/reviving_ontology_api_stuff.py
+++ b/enclave_wrangler/reviving_ontology_api_stuff.py
@@ -25,7 +25,7 @@ from fastapi import FastAPI, Query, Request
 from fastapi.middleware.cors import CORSMiddleware
 # from pandasql import sqldf
 from pydantic import BaseModel
-from enclave_wrangler.config import config, FAVORITE_DATASETS
+from enclave_wrangler.config import config, DATASET_REGISTRY
 import jq
 
 

--- a/test/test_enclave_wrangler/test_objects_api.py
+++ b/test/test_enclave_wrangler/test_objects_api.py
@@ -125,7 +125,7 @@ class TestObjectsApi(unittest.TestCase):
         with get_db_connection(schema=TEST_SCHEMA) as con:
             # Setup
             n1: int = sql_count(con, 'concept_set_container')
-            csets_and_members_to_db(con, TEST_SCHEMA, csets_and_members)
+            csets_and_members_to_db(con, csets_and_members, TEST_SCHEMA)
             t1 = datetime.now()  # temp
             n2: int = sql_count(con, 'concept_set_container')
             print('test_csets_and_members_to_db() setup completed in ', (t1 - t0).seconds, ' seconds')  # temp


### PR DESCRIPTION
Updates
```
    DB refresh: Vocab and counts tables
    - Add: refresh_voc_and_counts.py
    - Add: refresh_voc_and_counts.yml

    DB refresh: general
    - Update: 0-members script: Added a todo
    - Add: DDL for concept_ancestor_plus
    - Bugfix: DDL for concept_relationship_plus: An extra comma was causing syntax error

    Enclave Wrangler
    - Update: Renamed 'FAVORITE_DATASETS' to 'DATASET_REGISTRY' and did the same for similarly named variables.
    - Update: Refactored download_datasets() to be easier to understand, less error prone, and more debuggable.t status
    - Update: Refactored get_last_update_vocab() to get_last_update_of_dataset(): This function is now general purpose.
    - Delete: get_last_update_vocab(): No longer needed. General purpose one was better fit for use in current case.
    - Update: refresh_termhub_core_cset_derived_tables_exec() -> refresh_derived_tables(): After creating CORE_CSET_DDL_MODULES and passing it in, this general purpose function now serve several different cases, as well as exhibit the exact same behavior for core derived tables. Now also knows automatically which views it needs to recreate, based on new VIEWS config constant and checkign that against the ddl_modules param.
    - Add: refresh_any_dependent_tables(): This is now called more directly rather than calling refresh_derived_tables(). Instead of passing the list of dervied tables you want refreshed, you pass the list of tables updated, and it figures out the derived tables to update in the correct order. Also added further utility functions to aid with this: get_dependent_tables_queue() and extract_keys_from_nested_dict().
    - Add: config.py: CORE_CSET_DDL_MODULES, VIEWS: Used by refresh_derived_tables(), and now these are in a convenient place with other configuration about database tables.

    Backend
    - Update: initialize(): Added missing 'relationship' table to DATASET_TABLES, utilized by load()
    - Add: to backend/db/config.py: DERIVED_TABLE_DEPENDENCIES: Maps out what tables are dependent o
n what. Can use this for a variety of different refresh situations to figure out which tables need u
pdating.
```