### PR TITLE
Bugfix: Backend perpetually down after connection error

### DIFF
--- a/backend/db/queries.py
+++ b/backend/db/queries.py
@@ -2,11 +2,14 @@
 from functools import cache
 from typing import List, Dict
 from fastapi import Query
+from sqlalchemy import Connection
+
 from backend.db.utils import sql_query, sql_query_single_col, get_db_connection, sql_in
 
 
-def get_concepts(concept_ids: List[int], con=get_db_connection(), table:str='concepts_with_counts') -> List:
+def get_concepts(concept_ids: List[int], con: Connection = None, table:str='concepts_with_counts') -> List:
     """Get information about concept sets the user has selected"""
+    con = con if con else get_db_connection()
     q = f"""
           SELECT *
           FROM {table}
@@ -15,8 +18,9 @@ def get_concepts(concept_ids: List[int], con=get_db_connection(), table:str='con
     return rows
 
 
-def get_vocab_of_concepts(id: List[int] = Query(...), con=get_db_connection(), table:str='concept') -> List:
+def get_vocab_of_concepts(id: List[int] = Query(...), con: Connection = None, table:str='concept') -> List:
     """Expecting only one vocab for the list of concepts"""
+    con = con if con else get_db_connection()
     q = f"""
           SELECT DISTINCT vocabulary_id
           FROM {table}
@@ -27,9 +31,9 @@ def get_vocab_of_concepts(id: List[int] = Query(...), con=get_db_connection(), t
     return vocabs[0]
 
 
-def get_vocabs_of_concepts(id: List[int] = Query(...), con=get_db_connection(),
-                           table:str='concept') -> Dict:
+def get_vocabs_of_concepts(id: List[int] = Query(...), con: Connection = None, table:str='concept') -> Dict:
     """Return dict of {vocab: concept_id list}"""
+    con = con if con else get_db_connection()
     q = f"""
           SELECT vocabulary_id, array_agg(concept_id) AS concept_ids
           FROM {table}

--- a/backend/db/utils.py
+++ b/backend/db/utils.py
@@ -483,8 +483,9 @@ def sql_query_single_col(*argv) -> List:
     return [r[0] for r in results]
 
 
-def show_tables(con=get_db_connection(), print_dump=True):
+def show_tables(con: Connection = None, print_dump=True):
     """Show tables"""
+    con = con if con else get_db_connection()
     query = """
         SELECT n.nspname as "Schema", c.relname as "Name",
               CASE c.relkind WHEN 'r' THEN 'table' WHEN 'v' THEN 'view' WHEN 'm' THEN 'materialized view' WHEN 'i' THEN 'index' WHEN 'S' THEN 'sequence' WHEN 's' THEN 'special' WHEN 't' THEN 'TOAST table' WHEN 'f' THEN 'foreign table' WHEN 'p' THEN 'partitioned table' WHEN 'I' THEN 'partitioned index' END as "Type",

--- a/enclave_wrangler/objects_api.py
+++ b/enclave_wrangler/objects_api.py
@@ -665,8 +665,9 @@ def items_to_atlas_json_format(items):
 
 
 # todo: split into get/update
-def get_codeset_json(codeset_id, con=get_db_connection(), use_cache=True, set_cache=True) -> Dict:
+def get_codeset_json(codeset_id, con: Connection = None, use_cache=True, set_cache=True) -> Dict:
     """Get code_set jSON"""
+    con = con if con else get_db_connection()
     if use_cache:
         jsn = sql_query_single_col(con, f"""
             SELECT json


### PR DESCRIPTION
- Bugfix: PendingRollbackError: When some error happened in our deployment, the DB connection was stuck in a permanent 'pending rollback' state. However, there was no way to roll back without re-deploying. The basic change needed here was that connection objects were being re-used, and were not set up in such a way that they could handle these types of issues. Changed every instance where this was happening to instead set up a new connection if no connection object was passed, rather than initializing the connection within the function definition. This was the source of the problem. The connection object being created within the definition gets created on the first call and is re-used on subsequent calls.