### PR TITLE
Bugfix: Refresh missing csets

### DIFF
--- a/.github/workflows/refresh_db.yml
+++ b/.github/workflows/refresh_db.yml
@@ -52,12 +52,11 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: Updating documentation in docs/backend/db/analysis.md
-      # todo: Temporarily leaving this commented out here until we verify that root cause  of missing csets(
-      #   https://github.com/jhu-bids/TermHub/issues/573) has been resolved (likely through
-      #   https://github.com/jhu-bids/TermHub/issues/574)
-#      - name: Fetch missing csets
-#        run: make fetch-missing-csets
-
+      # todo: This should not be necessary, but some csets still not being fetched. Some thoughts in related issues:
+      #   https://github.com/jhu-bids/TermHub/issues/573
+      #   https://github.com/jhu-bids/TermHub/issues/574
+      - name: Fetch missing csets
+        run: make fetch-missing-csets
       # Test
       # todo: add more tests, ideally
       - name: Test missing csets

--- a/test/test_database.py
+++ b/test/test_database.py
@@ -15,13 +15,13 @@ sys.path.insert(0, str(PROJECT_ROOT))
 from enclave_wrangler.objects_api import get_bidirectional_csets_sets
 
 FAIL_MSG = (
-    "Found concept sets in the Enclave that were missing from TermHub.\n"
+    "\n\nFound concept sets in the Enclave that were missing from TermHub.\n"
     "Possible causes: (i) New csets were added recently (unlikely if this test was run via on schedule via "
     "GitHub action, which runs a couple hours after the refresh. Could possibly indicate problem with refresh."
     "\n(ii) Csets that were drafts before are now no longer drafts. This will be fixed when via "
     "https://github.com/jhu-bids/TermHub/issues/398\n"
     "For now, this can be fixed by running: make fetch-missing-csets\n"
-    "The following concept sets are missing from the database: ")
+    "The following concept sets are missing from the database: {}")
 
 class TestDatabaseCurrent(unittest.TestCase):
     """Tests for database"""
@@ -39,7 +39,7 @@ class TestDatabaseCurrent(unittest.TestCase):
         #     missing_from_db = [cset for cset in enclave_codesets if cset['codesetId'] in missing_ids_from_db]
         #     drafts = [cset for cset in missing_from_db if cset['isDraft']]
         #     notdrafts = [cset for cset in missing_from_db if not cset['isDraft']]
-        self.assertEqual(missing_ids_from_db, set(), msg=FAIL_MSG)
+        self.assertEqual(missing_ids_from_db, set(), msg=FAIL_MSG.format(missing_ids_from_db))
 
     def test_all_termhub_csets_in_enclave(self):
         """Test that TermHub concept sets are in the Enclave"""


### PR DESCRIPTION
For some reason, the DB refresh is not capturing all new csets. Until we find and fix the root problem (if we ever do), we have a workaround; a function that will find any missing csets and fetch them.