### PR TITLE
Bug: Refresh: Failing on blank container ID

### DIFF
--- a/backend/db/refresh.py
+++ b/backend/db/refresh.py
@@ -66,7 +66,6 @@ def refresh_db(
             # todo: when ready, will use all_new_objects_enclave_to_db() instead of csets_and_members_enclave_to_db()
             new_data: bool = csets_and_members_enclave_to_db(con, since, schema=schema)
         except Exception as err:
-            pass
             update_db_status_var('last_refresh_result', 'error', local)
             update_db_status_var('refresh_status', 'inactive', local)
             print(f"Database refresh incomplete; exception occurred. Tallying counts and exiting.", file=sys.stderr)


### PR DESCRIPTION
## Updates
- Bugfix: Unhandled case where container ID could not be fetched, and container ID was blank. This was the result of TermHub just recently gaining full access to cset dra
fts. We were fetching all drafts, including ones from when sourceApplicationVersion w
as 1.0 (we're now on 2.0), which was a different data model which had no containers.
Incompatible with TermHub, so we are filtering out and not importing these csets.

## The issue
See log: https://github.com/jhu-bids/TermHub/actions/runs/6489411749/job/17623626419
```
ValueError: Enclave API returned cset version with container of id , but failed to call data for that specific container.
```