### PR TITLE
Bugfix: `reset_temp_refresh_tables()`

### DIFF
--- a/backend/db/analysis.py
+++ b/backend/db/analysis.py
@@ -58,7 +58,7 @@ def _current_counts(
             return df
     # Get tables
     with get_db_connection(schema=schema, local=local) as con:
-        tables: List[str] = list_tables(con, filter_temp_refresh_tables=filter_temp_refresh_tables)
+        tables: List[str] = list_tables(con, _filter_temp_refresh_tables=filter_temp_refresh_tables)
     with get_db_connection(schema='', local=local) as con:
         # Get previous counts
         timestamps: List[datetime] = [


### PR DESCRIPTION
## Overview
Fixes bug where temp table could not be dropped because of dependent views.

## Updates
    Bugfix: reset_temp_refresh_tables()
    - Bugfix: reset_temp_refresh_tables(): Would error out because could not drop table with dependent views without CASCADE.
    - Add: filter_temp_refresh_tables()
    - Add: list_views()