### PR TITLE
Bugfix: Follow-up fix for derived views

### DIFF
--- a/backend/db/config.py
+++ b/backend/db/config.py
@@ -90,19 +90,6 @@ CORE_CSET_DEPENDENT_TABLES = [
     # 'csets_to_ignore',
     'cset_members_items_plus',
 ]
-
-# todo: remove obsolete view config code. can probably remove these
-# todo: obsoleted due to list_views()
-# VIEWS = [
-#     'cset_members_items_plus',
-#     # 'csets_to_ignore',
-# ]
-# todo: temporarily deactivating VIEWS_TO_REFRESH because it causes bugs since this view also needs to be removed
-#  elsewhere in the codebase. If we choose to keep the view, these 2 lines should be deleted. Otherwise if we remove
-#  the view (from both the DB and all references in codebase), there will proably be no need for these two lines either
-# VIEWS_REFRESH_IGNORE_LIST = ['cset_members_items_plus']
-# VIEWS_TO_REFRESH = list(set(list_views()) - set(VIEWS_REFRESH_IGNORE_LIST))
-
 # DERIVED_TABLE_DEPENDENCY_MAP: Shows which tables are needed to create a derived table. Generally the idea is that when
 #  the dependency tables are updated, the dependent table also needs to be updated. But some tables in here have
 #  dependencies but do not meet that use case. for example, 'concept_set_members_with_dups' depends on

--- a/backend/db/config.py
+++ b/backend/db/config.py
@@ -79,22 +79,30 @@ DB_URL = BRAND_NEW_DB_URL.replace(f'{CONFIG["port"]}', f'{CONFIG["port"]}/{CONFI
 REFRESH_JOB_MAX_HRS = 6  # see is_refresh_active() for documentation on this var
 CORE_CSET_TABLES = ['code_sets', 'concept_set_container', 'concept_set_version_item', 'concept_set_members']
 CORE_CSET_DEPENDENT_TABLES = [
+    # tables
     'cset_members_items',
     'codeset_ids_by_concept_id',
     'concept_ids_by_codeset_id',
     'members_items_summary',
     'codeset_counts',
     'all_csets',
+    # views
     # 'csets_to_ignore',
     'cset_members_items_plus',
 ]
-# todo: try to auto detect what is a view
-VIEWS = [
-    'cset_members_items_plus',
-    # 'csets_to_ignore',
-]
-VIEWS_REFRESH_IGNORE_LIST = ['cset_members_items_plus']
-VIEWS_TO_REFRESH = list(set(VIEWS) - set(VIEWS_REFRESH_IGNORE_LIST))
+
+# todo: remove obsolete view config code. can probably remove these
+# todo: obsoleted due to list_views()
+# VIEWS = [
+#     'cset_members_items_plus',
+#     # 'csets_to_ignore',
+# ]
+# todo: temporarily deactivating VIEWS_TO_REFRESH because it causes bugs since this view also needs to be removed
+#  elsewhere in the codebase. If we choose to keep the view, these 2 lines should be deleted. Otherwise if we remove
+#  the view (from both the DB and all references in codebase), there will proably be no need for these two lines either
+# VIEWS_REFRESH_IGNORE_LIST = ['cset_members_items_plus']
+# VIEWS_TO_REFRESH = list(set(list_views()) - set(VIEWS_REFRESH_IGNORE_LIST))
+
 # DERIVED_TABLE_DEPENDENCY_MAP: Shows which tables are needed to create a derived table. Generally the idea is that when
 #  the dependency tables are updated, the dependent table also needs to be updated. But some tables in here have
 #  dependencies but do not meet that use case. for example, 'concept_set_members_with_dups' depends on
@@ -114,10 +122,10 @@ DERIVED_TABLE_DEPENDENCY_MAP = {
     'concepts_with_counts_ungrouped': ['concept', 'deidentified_term_usage_by_domain_clamped'],
     'cset_members_items': ['concept_set_members', 'concept_set_version_item'],
     'members_items_summary': ['cset_members_items'],
+    'concept_graph': ['concept_ancestor'],
     # - views
     # 'csets_to_ignore': ['all_csets'],
     'cset_members_items_plus': ['cset_members_items', 'concept'],
-    'concept_graph': ['concept_ancestor'],
 
     # Unfinished / unsure
     # - unsure what to do with these. they probably aren't derived either


### PR DESCRIPTION
## Overview
Siggie (and I) tried to do a fix involving refreshing of views. However Siggie felt we either didn't need view or did not need to refresh it, and so tried to deal with that. I cleaned up some of that code, but at the time neither of us realized that this would be insufficient.

I've since fixed the error caused involving views and resetting of table status when refresh fails. I can't remember if Siggie actually wants to get rid of the view(s) or not, so I'm keeping them. I'm just getting rid of the bug that errors out during the reset.

## Changes
    Bugfix: Error on views during DB refresh table reset
    - Bugfix: A different PR recently fixed the original bug, but kept the views. But a new bug was introduced, causing the view to sometimes be recognized and sometimes not. This fixes that.

    General
    - Add: reset_refresh_state(): Resets both temporary tables and status variables
    - Add: reset_refresh_status(): Reset DB refresh active status variables to reflect non-active status


    - Delete: Obsolete view related config code