### PR TITLE
`last_refresh_success` fix / redundancy & refresh action tweak

### DIFF
--- a/.github/workflows/refresh_db.yml
+++ b/.github/workflows/refresh_db.yml
@@ -52,11 +52,11 @@ jobs:
         uses: stefanzweifel/git-auto-commit-action@v4
         with:
           commit_message: Updating documentation in docs/backend/db/analysis.md
-      # todo: This should not be necessary, but some csets still not being fetched. Some thoughts in related issues:
-      #   https://github.com/jhu-bids/TermHub/issues/573
-      #   https://github.com/jhu-bids/TermHub/issues/574
-      - name: Fetch missing csets
-        run: make fetch-missing-csets
+      # fetch-missing-csets: Deactivated because various tweaks and default re-refresh buffer solve this problem, and
+      # also test-missing-csets is there as a redundancy. Original context:
+      # https://github.com/jhu-bids/TermHub/issues/573 https://github.com/jhu-bids/TermHub/issues/574
+#      - name: Fetch missing csets
+#        run: make fetch-missing-csets
       # Test
       # todo: add more tests, ideally
       - name: Test missing csets


### PR DESCRIPTION
## Changes
    - Update: last_refresh_success time now set to 1 microsecond after last_refresh_request, as redundancy in order to ensure that no new data that was added in this timeframe is missed.
    - Update: DB refresh action: Deactivated fetch-missing-csets, as various tweaks, including 2 hour re-refresh buffer, and also test-missing-csets, have made this redundant and it just slows down the refresh.