### PR TITLE
Bugfix: refresh: KeyError: 'archived'

### DIFF
--- a/enclave_wrangler/objects_api.py
+++ b/enclave_wrangler/objects_api.py
@@ -671,10 +671,10 @@ def concept_set_members__cset_rows_to_db(con: Connection, cset: Dict, members: L
         'codeset_id': cset['codesetId'],
         'concept_id': member['conceptId'],
         'concept_set_name': cset['conceptSetNameOMOP'],
-        'is_most_recent_version': cset['isMostRecentVersion'], # not sure: is this correct?
-        'version': cset['version'], # not sure: is this correct?
+        'is_most_recent_version': cset['isMostRecentVersion'],
+        'version': cset['version'],
         'concept_name': member['conceptName'],
-        'archived': container['archived'], # not sure: is this correct?
+        'archived': container.get('archived', False),
     } for member in members]
     insert_from_dicts(con, 'concept_set_members', table_objs, skip_if_already_exists=True)
 


### PR DESCRIPTION
## Changes
    Bugfix: DB refresh: KeyError: 'archived'
    The cause of this was that apparently when you create concept sets in a certain way (I'm guessing via the API), some fields that are normally populated (normally required?) do not get populated, such as 'alias' and 'archived'.
    - Bugfix: Now sets 'archived' to False if not detected
    - Delete: Some comments