### PR TITLE
Bugfixes: `fetch_failures_0_members()`

### DIFF
--- a/backend/db/initialize.py
+++ b/backend/db/initialize.py
@@ -59,6 +59,7 @@ DDL_FETCH_AUDIT = """
     "table" text not null,
     primary_key text not null,
     status_initially text not null,
+    error_datetime timestamp with time zone,
     success_datetime timestamp with time zone,
     comment text);"""
 

--- a/backend/db/resolve_fetch_failures_0_members.py
+++ b/backend/db/resolve_fetch_failures_0_members.py
@@ -7,8 +7,9 @@ import sys
 import time
 from argparse import ArgumentParser
 from datetime import datetime
-from typing import Dict, List
+from typing import Dict, List, Set, Tuple
 
+from backend.utils import call_github_action
 
 DB_DIR = os.path.dirname(os.path.realpath(__file__))
 BACKEND_DIR = os.path.join(DB_DIR, "..")
@@ -35,24 +36,46 @@ def _report_success(
         success_rows.append(row)
     fetch_status_set_success(success_rows, use_local_db)
 
+
+def resolve_failures_0_members_if_exist(use_local_db=False, via_github_action=True):
+    """Starts handling of fetch failurers if they exist. Applies only to schema SCHEMA."""
+    failures: List[Dict] = select_failed_fetches(use_local_db)
+    failures_exist: bool = any([int(x['primary_key']) for x in failures if x['status_initially'] == 'fail-0-members'])
+    if failures_exist and via_github_action:
+        call_github_action('resolve_fetch_failures_0_members.yml')
+    elif failures_exist:
+        resolve_fetch_failures_0_members(use_local_db=use_local_db)
+
+
+def get_failures_0_members(version_id: int = None, use_local_db=False) -> Tuple[Set[int], Dict[str, Dict]]:
+    """Gets list of IDs of failed concetp set versions as well as a lookup for more information about them"""
+    failures: List[Dict] = select_failed_fetches(use_local_db)
+    failure_lookup: Dict[str, Dict] = {x['primary_key']: x for x in failures}
+    failed_cset_ids: List[int] = [version_id] if version_id else [
+        int(x['primary_key']) for x in failures if x['status_initially'] == 'fail-0-members']
+    failed_cset_ids: Set[int] = set(failed_cset_ids)  # dedupe
+    return failed_cset_ids, failure_lookup
+
+
 def resolve_fetch_failures_0_members(
-    version_id: int = None, use_local_db=False, polling_interval_seconds=30, schema=SCHEMA
+    version_id: int = None, use_local_db=False, polling_interval_seconds=30, schema=SCHEMA, runtime=2 * 60 * 60,
+    loop=False
 ):
     """Resolve situations where we tried to fetch data from the Enclave, but failed due to the concept set being too new
     resulting in initial fetch of concept set members being 0.
     :param version_id: Optional concept set version ID to resolve. If not provided, will check database for flagged
     failures.
+    :param runtime: 2 hours
+    :param loop: If True, will run in a loop to keep attempting to fetch. If this is set to False, it's probably
+    because the normal DB refresh rate is already high, and this action runs at the end of every refresh (if there are
+    any outstanding issus), so it's not really necessary to run these two concurrently.
     todo: Performance: Fetch only members, ideally: Even though we are fetching 'members', adding to the cset members
      table requires cset version and container metadata, and the function that does this expects them to be formaatted
      as objects, not as they come from our DB. We can fetch from DB and then convert to objects, but a lot of work for
      small performance gain."""
-    print("Resolving fetch failures: non-draft, ostensibly new concept sets with >0 expressions but 0 members")
+    print("Resolving fetch failures: ostensibly new (possibly draft) concept sets with >0 expressions but 0 members")
     # Collect failures
-    failures: List[Dict] = select_failed_fetches(use_local_db)
-    failure_lookup: Dict[str, Dict] = {x['primary_key']: x for x in failures}
-    failed_cset_ids: List[int] = [version_id] if version_id else [
-        int(x['primary_key']) for x in failures if x['status_initially'] == 'fail-0-members']
-    failed_cset_ids = list(set(failed_cset_ids))  # dedupe
+    failed_cset_ids, failure_lookup = get_failures_0_members(version_id, use_local_db)
     if not failed_cset_ids:
         print("No failures to resolve.")
         return
@@ -60,46 +83,57 @@ def resolve_fetch_failures_0_members(
     # Resolve
     i = 0
     t0 = datetime.now()
+    cset_is_draft_map: Dict[int, bool] = {}
     print(f"Fetching concept set versions and their related objects: {', '.join([str(x) for x in failed_cset_ids])}")
-    while len(failed_cset_ids) > 0 and (datetime.now() - t0).total_seconds() < 2 * 60 * 60:  # 2 hours
+    while len(failed_cset_ids) > 0 and (datetime.now() - t0).total_seconds() < runtime:
         i += 1
         print(f"- attempt {i}: fetching members for {len(failed_cset_ids)} concept set versions")
+        # Check for new failures: that may have occurred during runtime
+        failed_cset_ids, failure_lookup_i = get_failures_0_members(version_id, use_local_db)
+        failure_lookup.update(failure_lookup_i)
         # Fetch data
         csets_and_members: Dict[str, List[Dict]] = fetch_cset_and_member_objects(
-            codeset_ids=failed_cset_ids, handle_issues=False)
+            codeset_ids=list(failed_cset_ids), flag_issues=False)
         # - filter success & track results
         csets_and_members['OMOPConceptSet'] = [
             x for x in csets_and_members['OMOPConceptSet'] if x['member_items']]
+        cset_is_draft_map.update({x['properties']['codesetId']: x['properties']['isDraft'] for x in csets_and_members['OMOPConceptSet']})
         success_cases: List[int] = [
             x['properties']['codesetId'] for x in csets_and_members['OMOPConceptSet']]
         failed_cset_ids = list(set(failed_cset_ids) - set(success_cases))
 
-        # Update DB
+        # Update DB & report success
         if success_cases:
             try:
                 with get_db_connection(schema=schema, local=use_local_db) as con:
                     concept_set_members__from_csets_and_members_to_db(con, csets_and_members)
                     refresh_derived_tables(con)
+                print(f"Successfully fetched concept set members for concept set versions: "
+                      f"{', '.join([str(x) for x in success_cases])}")
+                _report_success(success_cases, failure_lookup, 'Success result: Found members', use_local_db)
             except Exception as err:
                 reset_temp_refresh_tables(schema)
                 raise err
 
-        # Report success
-        if success_cases:
-            print(f"Successfully fetched concept set members for concept set versions: "
-                  f"{', '.join([str(x) for x in success_cases])}")
-            _report_success(success_cases, failure_lookup, 'Success result: Found members', use_local_db)
-
-        # Sleep
+        # Sleep or exit
+        if not loop:
+            break
         time.sleep(polling_interval_seconds)
 
+    # Remove drafts from failures (as csets don't have members until drafts are finalized)
+    failed_cset_ids = [cset_id for cset_id in failed_cset_ids if cset_is_draft_map[cset_id]]
+
     # Close out
-    if failed_cset_ids:
+    if failed_cset_ids and loop:
         print(f"2 hours have passed. No members were fetched for the following concept sets, but given the length "
               f"of time passed, members should have been available by now, and we assume that these concept sets do"
               f" not actually have members. Reporting resolved: {', '.join([str(x) for x in failed_cset_ids])}")
         comment = 'Success result: No members after 2 hours. Considering resolved.'
         _report_success(failed_cset_ids, failure_lookup, comment, use_local_db)
+    elif failed_cset_ids:
+        raise RuntimeError('Attempted to resolve fetch failures for the following concept sets, but was not able to do '
+                           'so. It may be that the Enclave simply has not expanded their members yet.:\n\n'
+                           f'{", ".join([str(x) for x in failed_cset_ids])}')
     else:
         print("All failures resolved.")
 


### PR DESCRIPTION
## The crux
New drafts were sometimes never getting members fetched.

## Partially addresses
- #520

## Changes
    Bug fixes: fetch_failures_0_members()
    - Bug fix: Now does not ignore this issue when the cset is a draft.
    - Update: Now does not try to fix the issue mid-refresh because of new param try_fixing_issues_immediately=False. Added comments regarding rationale.
    - Update: Now addresses issus at end of refresh if for resolve_fetch_failures_0_members (set to True), but not for resolve_fetch_failures_excess_items (set to False), due to outstanding issues with that action.
    - Update: Fetch failures action / script: No longer runs for 2 hours. Just runs once and quits even if it could not fix the issue. Rationale: refresh runs every 20 minutes, so it will try again soon.
    - Update: Fetch audit table: add: error_datetime field
    - Bug fix: Action now doesn't fail if cset is still a draft when the refresh completes.

## Additional todo's if time
- [x] Add a timestamp for when the problematic cset w/ fetch failure first occurred (not just when it was successfully fetched)
- [x] Re-run refresh with `--since` to update csets with 0 members that are no longer drafts
- [x] FYI: to do later: `fetch_failures_excessive_items`: There are only cases of this once every year or two, so this is super low priority.