### PR TITLE
Kill idle cons

### DIFF
--- a/.github/workflows/kill_idle_cons.yml
+++ b/.github/workflows/kill_idle_cons.yml
@@ -1,0 +1,40 @@
+# Kill idle connections older than 10 minutes
+name: Kill idle connections
+
+on:
+  schedule:
+    - cron: '0 */3 * * * '  # every 3 hours
+  workflow_dispatch:
+jobs:
+  kill-idle-cons:
+    runs-on: ubuntu-latest
+    steps:
+      # Set up
+      - name: Checkout repository and submodules
+        uses: actions/checkout@v2
+      - name: Set up Python version
+        uses: actions/setup-python@v2
+        with:
+          # Consider '3.10' or 'v3.10.0': https://github.com/actions/setup-python/issues/160
+          python-version: '3.9.7'  # Not sure why 3.9.7 here and 3.9 elsewhere. the .7 works on Mac, but not on Ubuntu
+
+      - name: 'Create env file'
+        run: |
+          mkdir env
+          echo "${{ secrets.ENV_FILE }}" > env/.env
+
+      - name: Create and start virtual environment
+        run: |
+          python3 -m venv venv
+          source venv/bin/activate
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install --upgrade wheel
+          pip install --upgrade setuptools
+          pip install -r requirements.txt
+
+      # Run the action
+      - name: Kill idle connections
+        run: make kill-idle-cons

--- a/backend/db/utils.py
+++ b/backend/db/utils.py
@@ -809,16 +809,35 @@ def get_idle_connections(interval: str = '1 week'):
     return result
 
 
+def kill_idle_cons(threshold_minutes=10):
+    """Kill idle connections older than threshold minutes
+
+    Kills only those connections having to do with TermHub."""
+    qry = f"""SELECT pg_terminate_backend(pid) FROM pg_stat_activity 
+    WHERE state = 'idle' and datname = 'termhub' and usename = 'thadmin' 
+    and state_change < NOW() - INTERVAL '{threshold_minutes} minutes';
+    """
+    with get_db_connection(schema='') as con:
+        run_sql(con, qry)
+
+
 def cli():
     """Command line interface"""
     parser = ArgumentParser(prog='termhub-db-utils', description='Database utilities.')
     parser.add_argument(
         '-f', '--reset-refresh-state', required=False, default=False, action='store_true',
         help='Resets both temporary tables and status variables')
+    parser.add_argument(
+        '-k', '--kill-idle-cons', required=False, default=False, action='store_true',
+        help='Kills any idle connections older than 10 minutes')
     d: Dict = vars(parser.parse_args())
+    if d['reset_refresh_state']:
+        print('Killing idle connections older than 10 minutes')
+        kill_idle_cons()
     if d['reset_refresh_state']:
         print('Resetting temporary tables and status variables')
         reset_refresh_state()
+
 
 
 if __name__ == '__main__':

--- a/makefile
+++ b/makefile
@@ -35,6 +35,9 @@ counts-help:
 backup:
 	sh ./db_backup.sh
 
+kill-idle-cons:
+	python backend/db/utils.py --kill-idle-cons
+
 # Testing
 test: test-backend test-frontend
 
@@ -108,6 +111,8 @@ help:
 	@printf "Show help for counts commands.\n\n"
 	@echo backup
 	@printf "Runs a script with instructions on how to do a database backup.\n\n"
+	@echo kill-idle-cons
+	@printf "Kills all idle connections older than 10 minutes.\n\n"
 	@echo test
 	@printf "Runs all backend and frontend tests.\n\n"
 	@echo test-backend


### PR DESCRIPTION
## Changes
Kill idle cons
Kills all idle TermHub related connections older than 10 minutes.
- Add: GitHub action: kill_idle_cons.yml
- Add: Make command: kill-idle-cons
- Add: CLI: backend/db/utils.py --kill-idle-cons
- Add: kill_idle_cons()