### PR TITLE
Bug: Vocab refresh fail: `concept_depth`

### DIFF
--- a/backend/db/analysis.py
+++ b/backend/db/analysis.py
@@ -173,10 +173,8 @@ def counts_over_time(
     dates = list(set(dateslist))
 
     finaldf = pd.DataFrame()
-    i = 0  # TODO: temp
     for date in dates:
-        i += 1  # TODO temp
-        # Create temporary table with the columns of only one date
+        # Create temporary table with the colimns of only one date
         # TODO: Is there still a bug here sometimes?
         datedf = df[df.columns[df.columns.str.startswith(date)]]
         datedf = datedf.sort_index(axis=1)

--- a/backend/db/config.py
+++ b/backend/db/config.py
@@ -124,8 +124,7 @@ DERIVED_TABLE_DEPENDENCY_MAP: Dict[str, List[str]] = {
     ],
     'codeset_counts': ['members_items_summary'],
     'codeset_ids_by_concept_id': ['cset_members_items'],
-    'concept_ancestor_plus': ['concept_ancestor', 'concepts_with_counts', 'concept_depth'],
-    'concept_depth': ['root_concepts', 'concept_ancestor'],
+    'concept_ancestor_plus': ['concept_ancestor', 'concepts_with_counts'],
     'concept_graph': ['concept_ancestor'],
     'concept_ids_by_codeset_id': ['cset_members_items'],
     'concept_relationship_plus': ['concept_relationship', 'concepts_with_counts'],
@@ -133,7 +132,6 @@ DERIVED_TABLE_DEPENDENCY_MAP: Dict[str, List[str]] = {
     'concepts_with_counts_ungrouped': ['concept', 'deidentified_term_usage_by_domain_clamped'],
     'cset_members_items': ['concept_set_members', 'concept_set_version_item'],
     'members_items_summary': ['cset_members_items'],
-    'root_concepts': ['concept_ancestor'],
 
     # - views
     # 'csets_to_ignore': ['all_csets'],

--- a/backend/db/ddl-14-concepts_with_counts.jinja.sql
+++ b/backend/db/ddl-14-concepts_with_counts.jinja.sql
@@ -21,4 +21,4 @@ CREATE TABLE IF NOT EXISTS {{schema}}concepts_with_counts{{optional_suffix}} AS 
 CREATE INDEX cc_idx1{{optional_index_suffix}} ON {{schema}}concepts_with_counts{{optional_suffix}}(concept_id);
 
 -- Index cwcgin takes some time to complete
-CREATE INDEX cwcgin{{optional_index_suffix}} ON concepts_with_counts{{optional_suffix}} USING gin (concept_name gin_trgm_ops);
+CREATE INDEX cwcgin{{optional_index_suffix}} ON {{schema}}concepts_with_counts{{optional_suffix}} USING gin (concept_name gin_trgm_ops);

--- a/backend/db/ddl-16-concept_ancestor_plus.jinja.sql
+++ b/backend/db/ddl-16-concept_ancestor_plus.jinja.sql
@@ -1,5 +1,5 @@
 -- Table: concept_ancestor_plus ------------------------------------------------------------------------------------
-
+-- Temp tables do not have {{optional_suffix}} for _new and _old becauser they do not get recreated during refreshes; they are temporary.
 CREATE TEMP TABLE root_concepts AS (
     SELECT ancestor_concept_id FROM {{schema}}concept_ancestor r WHERE min_levels_of_separation != 0
     EXCEPT

--- a/backend/db/ddl-5-concept_set_container.jinja.sql
+++ b/backend/db/ddl-5-concept_set_container.jinja.sql
@@ -2,6 +2,7 @@
 -- has duplicate records except for the created_at col. get rid of duplicates, keeping the most recent.
 --  code FROM {{schema}}https://stackoverflow.com/a/28085614/1368860
 --      which also has code that works for databases other than postgres, if we ever need that
+-- Doesn't have {{optional_suffix}} for _old and _new because this is a core table and won't be re-created during refreshes.
 WITH deduped AS (
     SELECT DISTINCT ON (concept_set_id) concept_set_id, created_at
     FROM {{schema}}concept_set_container

--- a/backend/db/ddl-6-cset_members_items.jinja.sql
+++ b/backend/db/ddl-6-cset_members_items.jinja.sql
@@ -1,4 +1,5 @@
 -- Table: cset_members_items -------------------------------------------------------------------------------------------
+-- Doesn't have {{optional_suffix}} for _old and _new because this is a core table and won't be re-created during refreshes.
 DROP TABLE IF EXISTS {{schema}}cset_members_items{{optional_suffix}} CASCADE;
 
 CREATE TABLE {{schema}}cset_members_items{{optional_suffix}} AS

--- a/backend/db/initialize.py
+++ b/backend/db/initialize.py
@@ -82,12 +82,14 @@ CREATE TABLE IF NOT EXISTS public.ip_info (
 #  BTREE_GIST     | Generalized Search Tree Index | No
 # Enabling extensions requires two steps:
 # 1. Enable them in the cloud, e.g. Azure: https://portal.azure.com/#@live.johnshopkins.edu/resource/subscriptions/fe24df19-d251-4821-9a6f-f037c93d7e47/resourceGroups/JH-POSTGRES-RG/providers/Microsoft.DBforPostgreSQL/flexibleServers/termhub/serverParameters
-# 2. Run SQL: CREATE EXTENSION <EXTENSION>;
-# If, when running initialize() there is an error because can't create the extension, try step (1) and enable in Azure.
+# 2. Run SQL: `CREATE EXTENSION <EXTENSION> WITH SCHEMA pg_catalog`;
+# - if, when running initialize() there is an error because can't create the extension, try step (1) and enable in Azure.
+# - `WITH SCHEMA pg_catalog`: This enables the extension for all schemas, which is good for future proofing. Currently
+# it will mainly be used in the main schema, `n3c`, but might also be used in the test schema, `test_n3c`.
 DDL_EXTENSIONS = """
-    CREATE EXTENSION PG_TRGM;
-    CREATE EXTENSION BTREE_GIN;
-    CREATE EXTENSION BTREE_GIST;"""
+    CREATE EXTENSION PG_TRGM WITH SCHEMA pg_catalog;
+    CREATE EXTENSION BTREE_GIN WITH SCHEMA pg_catalog;
+    CREATE EXTENSION BTREE_GIST WITH SCHEMA pg_catalog;"""
 
 def create_database(con: Connection, schema: str):
     """Create the database"""

--- a/test/test_backend/db/test_refresh_dataset_group_tables.py
+++ b/test/test_backend/db/test_refresh_dataset_group_tables.py
@@ -99,7 +99,10 @@ class TestRefreshDatasetGroupTables(DbRefreshTestWrapper, DatasetGroupAnalysis):
         _set_up_vocab()
 
     def test_load_dataset_group(self):
-        """"Test load_dataset_group()"""
+        """"Test load_dataset_group(). This is what does the most work in refresh_dataset_group_tables()."""
+        # TODO: temp ------------------
+        del TABLES_BY_GROUP['counts']
+
         for group_name in TABLES_BY_GROUP.keys():
             load_dataset_group(group_name, TEST_SCHEMA, THIS_INPUT_DIR / group_name)
             self._check_indexes_and_pkeys(group_name)

--- a/test/test_backend/db/test_refresh_dataset_group_tables.py
+++ b/test/test_backend/db/test_refresh_dataset_group_tables.py
@@ -100,9 +100,6 @@ class TestRefreshDatasetGroupTables(DbRefreshTestWrapper, DatasetGroupAnalysis):
 
     def test_load_dataset_group(self):
         """"Test load_dataset_group(). This is what does the most work in refresh_dataset_group_tables()."""
-        # TODO: temp ------------------
-        del TABLES_BY_GROUP['counts']
-
         for group_name in TABLES_BY_GROUP.keys():
             load_dataset_group(group_name, TEST_SCHEMA, THIS_INPUT_DIR / group_name)
             self._check_indexes_and_pkeys(group_name)


### PR DESCRIPTION
## Changes
    Bug fix: Vocab refresh error
    - Bug fix: Fixed error in which temporary tables were being treated as permanent, which caused error when it tried to manipulate a table that was no longer there.
    - Update: Enabled extensions for all schema, so they are available for testing and future proof situations where extension is needed.
    - Bug fix: Removed temp tables from config, which was causing them to update when they should not (caused error).

    General
    - Bug fixes: Jinja updates to SQL DDL, fixing various possible unforeseen current and/or future issues.
    - Delete: Some old no-op temp code