### PR TITLE
Bug fix: NULL concept name

### DIFF
--- a/enclave_wrangler/objects_api.py
+++ b/enclave_wrangler/objects_api.py
@@ -740,7 +740,7 @@ def concept_set_members__cset_rows_to_db(con: Connection, cset: Dict, members: L
         'concept_set_name': cset['conceptSetNameOMOP'],
         'is_most_recent_version': cset['isMostRecentVersion'],
         'version': cset['version'],
-        'concept_name': member['conceptName'],
+        'concept_name': member.get('conceptName', None),
         'archived': container.get('archived', False),
     } for member in members]
     insert_from_dicts(con, 'concept_set_members', table_objs, skip_if_already_exists=True)


### PR DESCRIPTION
## Changes
Bug fix: NULL concept name
- When adding concept_members to the DB, if there was no concept name, would cause an exception.