### PR TITLE
DB refresh: by `codeset_id`

### DIFF
--- a/.github/workflows/refresh_db.yml
+++ b/.github/workflows/refresh_db.yml
@@ -15,6 +15,11 @@ on:
         description: 'Optional: YYYY-MM-DD or YYYY-MM-DDTHH:MM:SS.SSSSSS+HH:MM'
         required: false
         type: string
+      cset-ids:
+        # Space-delimited list of integers representing codeset IDs
+        description: 'Optional: Space-delimited list of integers representing codeset IDs'
+        required: false
+        type: string
   repository_dispatch:
     types: [refresh-db]
 jobs:
@@ -57,10 +62,15 @@ jobs:
       # Refresh
       - name: Refresh db
         run: |
-          if [ -z "${{ github.event.inputs.since }}" ]; then
-            python backend/db/refresh.py
-          else
+          if [ -n "${{ github.event.inputs.cset-ids }}" ] && [ -n "${{ github.event.inputs.since }}" ]; then
+            echo "Error: Both 'cset-ids' and 'since' were provided. These inputs are mutually exclusive."
+            exit 1
+          elif [ -n "${{ github.event.inputs.cset-ids }}" ]; then
+            python backend/db/refresh.py --cset-ids ${{ github.event.inputs.cset-ids }}
+          elif [ -n "${{ github.event.inputs.since }}" ]; then
             python backend/db/refresh.py --since ${{ github.event.inputs.since }}
+          else
+            python backend/db/refresh.py
           fi
       - name: Commit changes to documentation
         uses: stefanzweifel/git-auto-commit-action@v4

--- a/backend/db/refresh.py
+++ b/backend/db/refresh.py
@@ -13,7 +13,7 @@ DB_DIR = os.path.dirname(os.path.realpath(__file__))
 BACKEND_DIR = os.path.join(DB_DIR, '..')
 PROJECT_ROOT = os.path.join(BACKEND_DIR, '..')
 sys.path.insert(0, str(PROJECT_ROOT))
-from backend.db.analysis import counts_update,counts_docs
+from backend.db.analysis import counts_update, counts_docs
 from backend.db.config import CONFIG
 from backend.db.resolve_fetch_failures_0_members import resolve_failures_0_members_if_exist, \
     resolve_failures_excess_items_if_exist
@@ -78,7 +78,7 @@ def _calc_refresh_datetime(
 def refresh_db(
     since: Union[datetime, str] = None, cset_ids: List[int] = None, use_local_db=False,  schema: str = CONFIG['schema'],
     force_non_contiguity=False, buffer_hours=DEFAULT_BUFFER_HOURS, resolve_fetch_failures_0_members=True,
-    resolve_fetch_failures_excess_items=False
+    resolve_fetch_failures_excess_items=False,
 ):
     """Refresh the database
 
@@ -104,7 +104,6 @@ def refresh_db(
     if since and cset_ids:
         raise NotImplementedError('Cannot pass both "since" and "cset_ids" params.')
 
-
     # Calculate: Start & end time
     # end_time: Even though in reality the refresh will not end 1 microsecond after the start time, we're setting it
     # this way because this is the easiest way to make sure that future refreshes will not miss any new data that was
@@ -124,6 +123,7 @@ def refresh_db(
     try:
         with get_db_connection(local=local) as con:
             since: str = _calc_refresh_datetime(con, since, buffer_hours, force_non_contiguity)
+            since = since if not cset_ids else None
             # todo: when ready, will use all_new_objects_enclave_to_db() instead of csets_and_members_enclave_to_db()
             # - csets_and_members_enclave_to_db(): Runs the refresh
             new_data: bool = csets_and_members_enclave_to_db(con, since, cset_ids, schema)
@@ -156,7 +156,7 @@ def refresh_db(
     if check_db_status_var('new_request_while_refreshing'):
         print('INFO: New refresh request detected while refresh was running. Starting a new refresh.')
         delete_db_status_var('new_request_while_refreshing')
-        refresh_db(None,cset_ids,  use_local_db, schema, force_non_contiguity)
+        refresh_db(None, None, use_local_db, schema, force_non_contiguity)
 
 
 def cli():
@@ -169,13 +169,12 @@ def cli():
         '-b', '--buffer-hours', default=DEFAULT_BUFFER_HOURS, required=False,
         help='An additional period of time before "since" to fetch additional data, as a failsafe measure in case of '
              'possible API unreliability. Somewhat redundant with fetch_failures_0_members process.')
-    parser.add_argument(
-        '-s', '--since', required=False,
-        help=HELP_SINCE)
-    parser.add_argument(
-        '-c', '--cset-ids', nargs='+', type=int, required=False,
-        help='Run just for certain code sets. Pass their IDs space-delimited, e.g. --cset-ids 123 456.')
+    parser.add_argument('-s', '--since', required=False, help=HELP_SINCE)
+    parser.add_argument("-c", "--cset-ids", type=int, required=False, nargs='+',
+        help="Run just for certain code sets. Pass their IDs space-delimited, e.g. --cset-ids 123 456. Should only be"
+             " passed without 'since'.")
     refresh_db(**vars(parser.parse_args()))
+
 
 if __name__ == '__main__':
     cli()


### PR DESCRIPTION
resolves #832

DB Refresh: Support cset-ids
- Bug fix: Was not setting 'since' to None if cset-ids was present.
- Bug fix: Was passing cset-ids to secondary refresh (if a user requested a refresh from the web app during that refresh). That isn't supported by the UI.
- Update: Some comments and other minor things.
- Update: Now supported by the GitHub actions