### PR TITLE
Bugfix: Fetch failures: `KeyError: 'parentVersionId'`

### DIFF
--- a/enclave_wrangler/models.py
+++ b/enclave_wrangler/models.py
@@ -399,17 +399,11 @@ def convert_row(source: str, target: str, row: Dict, skip_missing_fields=True, k
             out[field] = row[field_name_mapping(target, source, field)]
         except KeyError as err:
             if keep_missing_fields:
-                out[field] = row[field]
+                try:
+                    out[field] = row[field]
+                except KeyError:
+                    if not skip_missing_fields:
+                        raise err
             elif not skip_missing_fields:
                 raise err
     return out
-
-
-if __name__ == '__main__':
-    # mappings = get_field_mappings()
-    # pdump(m)
-    # t = field_name_mapping('concept', 'concept_id', 'atlasjson')
-    # print(t)
-    # t = field_name_mapping('concept', 'domain_id', 'atlasjson')
-    # print(t)
-    print()

--- a/enclave_wrangler/objects_api.py
+++ b/enclave_wrangler/objects_api.py
@@ -1090,6 +1090,9 @@ def update_cset_metadata_from_objs(
      timestamp, you see the before/after for each cset, rather than all of the csets before the update, then all the
      csets after the update, with all the timestamps in the before/after sets being equal due to the same audit_query
      for each set.
+    todo: If errors after the 1st audit table entry but before the 2nd, it should delete the 1st audit query. There
+     should only be ever 2 rows for a single update: the before and after. It might also help in this case to have a
+     special PK for such things so that the pair for each before/after update can easily be identified.
     """
     conn = con if con else get_db_connection()
     cset_objs = cset_objs if isinstance(cset_objs, list) else [cset_objs]


### PR DESCRIPTION
Follow-up from #836.

The cause of the bug ([GH action log](https://github.com/jhu-bids/TermHub/actions/runs/10670888366/job/29575743532)) is that a certain field was missing from the enclave object returned. Normally during `convert_row()`, if this happens, the `KeyError` is skipped. However, `convert_row()` behaves differently now when it is used by DB update functions, and I hadn't accounted for skipping past this `KeyError` in that case.