### PR TITLE
Bug fix: GitHub action deprecated module

### DIFF
--- a/.github/workflows/backend_dev.yml
+++ b/.github/workflows/backend_dev.yml
@@ -62,7 +62,7 @@ jobs:
 #        run: python -m unittest discover -v
       # About: https://azure.github.io/AppService/2020/12/11/cicd-for-python-apps.html
       - name: Upload artifact for deployment jobs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: python-app
           path: |

--- a/.github/workflows/backend_prod.yml
+++ b/.github/workflows/backend_prod.yml
@@ -62,7 +62,7 @@ jobs:
 #        run: python -m unittest discover -v
       # About: https://azure.github.io/AppService/2020/12/11/cicd-for-python-apps.html
       - name: Upload artifact for deployment jobs
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: python-app
           path: |

--- a/.github/workflows/test_frontend_e2e_live_dev.yml
+++ b/.github/workflows/test_frontend_e2e_live_dev.yml
@@ -52,7 +52,7 @@ jobs:
     # Run tests
     - name: Run Playwright tests
       run: make test-frontend-e2e-dev
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: always()
       with:
         name: playwright-report
@@ -81,7 +81,7 @@ jobs:
 #      run: yarn playwright install --with-deps # Use yarn to run playwright install
 #    - name: Run Playwright tests
 #      run: yarn playwright test # Use yarn to run playwright test
-#    - uses: actions/upload-artifact@v3
+#    - uses: actions/upload-artifact@v4
 #      if: always()
 #      with:
 #        name: playwright-report

--- a/.github/workflows/test_frontend_e2e_live_dev_running_local.yml
+++ b/.github/workflows/test_frontend_e2e_live_dev_running_local.yml
@@ -53,7 +53,7 @@ jobs:
     # Run tests
     - name: Run Playwright tests
       run: make test-frontend-e2e-dev
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: always()
       with:
         name: playwright-report
@@ -82,7 +82,7 @@ jobs:
 #      run: yarn playwright install --with-deps # Use yarn to run playwright install
 #    - name: Run Playwright tests
 #      run: yarn playwright test # Use yarn to run playwright test
-#    - uses: actions/upload-artifact@v3
+#    - uses: actions/upload-artifact@v4
 #      if: always()
 #      with:
 #        name: playwright-report

--- a/.github/workflows/test_frontend_e2e_live_prod.yml
+++ b/.github/workflows/test_frontend_e2e_live_prod.yml
@@ -55,7 +55,7 @@ jobs:
     # Run tests
     - name: Run Playwright tests
       run: make test-frontend-e2e-prod
-    - uses: actions/upload-artifact@v3
+    - uses: actions/upload-artifact@v4
       if: always()
       with:
         name: playwright-report
@@ -84,7 +84,7 @@ jobs:
 #      run: yarn playwright install --with-deps # Use yarn to run playwright install
 #    - name: Run Playwright tests
 #      run: yarn playwright test # Use yarn to run playwright test
-#    - uses: actions/upload-artifact@v3
+#    - uses: actions/upload-artifact@v4
 #      if: always()
 #      with:
 #        name: playwright-report


### PR DESCRIPTION
## Changes
Bug fix: GitHub action changes
- Update: GitHub deprecated certain actions that were being used by our actions: https://github.blog/changelog/2024-02-13-deprecation-notice-v1-and-v2-of-the-artifact-actions/. Even though they were just deprecated, it caused an error from our actions still being on the old version.