### PR TITLE
Sync Draft Expression Items

### DIFF
--- a/enclave_wrangler/models.py
+++ b/enclave_wrangler/models.py
@@ -281,7 +281,9 @@ add_mappings(
        includeMapped,                includeMapped
        isExcluded,                   isExcluded
        createdBy,                    created_by
-       createdAt,                    created_at""")
+       createdAt,                    created_at
+       annotation,                   annotation
+       sourceApplication,            source_application""")
 
 # OMOPConceptSet (Version): object <-> dataset
 add_mappings(


### PR DESCRIPTION
## Changes
Sync Draft Expression Items
- Now syncing added or deleted expression items while csets are drafts or are finalized.

General
- Bug fix: When adding expression items, values for 'annotation' and 'sourceApplciation' fields were being dropped.